### PR TITLE
changed custom_edit_url to point to developer.sailpoint.com repo

### DIFF
--- a/api.mustache
+++ b/api.mustache
@@ -22,7 +22,7 @@ sidebar_class_name: "{{{api.method}}} api-method"
 {{#infoPath}}
 info_path: {{{infoPath}}}
 {{/infoPath}}
-custom_edit_url: "https://github.com/sailpoint-oss/api-specs/issues/new?labels=API%20Specs&title=[Documentation] Requesting changes to '{{{title}}}' ({{{id}}})"
+custom_edit_url: "https://github.com/sailpoint-oss/developer.sailpoint.com/issues/new?assignees=&labels=&template=bug-report.md&title=%5BBug%5D+Your+Bug+Report+Here Requesting changes to '{{{title}}}' ({{{id}}})"
 ---
 
 {{{markdown}}}


### PR DESCRIPTION
The custom_edit_url for the API spec documents originally pointed to sailpoint-oss/api-specs. I believe we should just point those requests to our issue requests here in this repo instead.