### PR TITLE
update access request dynamic approver trigger

### DIFF
--- a/products/idn/docs/identity-now/event-triggers/available/access-request-dynamic-approval.md
+++ b/products/idn/docs/identity-now/event-triggers/available/access-request-dynamic-approval.md
@@ -110,10 +110,14 @@ to the event trigger with the following payload:
 ```
 
 If no identity or group should be added to a particular access request, then the
-subscribing service responds with an empty object:
+subscribing service responds with empty object in below format:
 
 ```json
-{}
+{
+  "id": "",
+  "name": "",
+  "type": ""
+ }
 ```
 
 ## Additional Information and Links


### PR DESCRIPTION
If we send the empty json object in format "{}" its throwing an error. We should send the empty string in identity data which worked for me.