### PR TITLE
Increased heading size for sorting results

### DIFF
--- a/products/idn/api/standard-collection-parameters.md
+++ b/products/idn/api/standard-collection-parameters.md
@@ -184,7 +184,7 @@ Examples:
 
 :::
 
-### Sorting Results
+## Sorting Results
 
 Result sorting is supported with the standard `sorters` parameter. Its syntax is a set of comma-separated field names. You may optionally prefix each field name with a "-" character, indicating that the sort is descending based on the value of that field. Otherwise, the sort is ascending.
 


### PR DESCRIPTION
The heading size for the Sorting Results section was one level too deep, underneath filters.  I bumped it up to give it its own section.