### PR TITLE
added documentation for password change and doc links

### DIFF
--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-delete.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-delete.md
@@ -18,6 +18,7 @@ tags: ['Connectivity', 'Connector Command']
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "john.doe"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-enable.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-enable.md
@@ -30,6 +30,7 @@ tags: ['Connectivity', 'Connector Command']
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "john.doe"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-list.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-list.md
@@ -18,6 +18,7 @@ tags: ['Connectivity', 'Connector Command']
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "john.doe"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-read.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-read.md
@@ -17,6 +17,7 @@ tags: ['Connectivity', 'Connector Command']
 ### Example StdAccountReadInput
 
 ```javascript
+"identity": "john.doe",
 "key": {
     "simple": {
         "id": "john.doe"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-unlock.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-unlock.md
@@ -17,6 +17,7 @@ tags: ['Connectivity', 'Connector Command']
 ### Example StdAccountUnlockInput
 
 ```javascript
+"identity": "john.doe",
 "key": {
     "simple": {
         "id": "john.doe"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-update.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/account-update.md
@@ -18,6 +18,7 @@ tags: ['Connectivity', 'Connector Command']
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "john.doe"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/change-password.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/change-password.md
@@ -1,0 +1,51 @@
+---
+id: change-password
+title: Change Password
+pagination_label: Change Password
+sidebar_label: Change Password
+keywords: ['connectivity', 'connectors', 'change password']
+description: Change password for an account on the source.
+slug: /docs/saas-connectivity/commands/change-password
+tags: ['Connectivity', 'Connector Command']
+---
+
+| Input/Output |       Data Type         |
+| :----------- | :--------------------:  |
+| Input        | StdChangePasswordInput  |
+| Output       | StdChangePasswordOutput |
+
+### Example StdChangePasswordInput
+
+```javascript
+"identity": "john.doe",
+"key": {
+    "simple": {
+        "id": "john.doe"
+    }
+},
+"password": "newPassword"
+```
+
+### Example StdChangePasswordOutput
+
+```javascript
+{}
+```
+
+## Description
+
+The change password command is triggered in IDN when a user changes their password through IDN. When this occurs, if your source has change password enabled, then you can change the user password on the source system through IDN. 
+
+## The Provisioning Plan
+
+The change password command sends the password change event to your connector whenever a user changes their password through the Password Manager. Handling this even is as simple as implementing a method on the source system that updates a users password
+
+```javascript
+.stdChangePassword(async (context: Context, input: StdChangePasswordInput, res: Response<StdChangePasswordOutput>) => {
+    res.send(await myClient.changePassword(input.identity))
+})
+```
+
+## Testing in IdentityNow
+
+In order to test in IdentityNow, the source application must be configured so that it is able to accept password change requests through the Password Manager. Once this setup is complete, you can log in as a user whose identity exists in the configured application and change their password in the Password Manager. 

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/entitlement-list.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/entitlement-list.md
@@ -26,6 +26,7 @@ tags: ['Connectivity', 'Connector Command']
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "administrator"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-commands/entitlement-read.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-commands/entitlement-read.md
@@ -24,6 +24,7 @@ At this time Entitlement Read is not triggered from IDN for any specific workflo
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "john.doe"
@@ -37,6 +38,7 @@ At this time Entitlement Read is not triggered from IDN for any specific workflo
 
 ```javascript
 {
+    "identity": "john.doe",
     "key": {
         "simple": {
             "id": "administrator"

--- a/products/idn/docs/identity-now/saas-connectivity/connector-spec/index.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-spec/index.md
@@ -38,6 +38,8 @@ The following describes in detail the different fields in the connector spec:
     - **type:** This is always "section" - it indicates a new section on the page
     - **sectionTitle:** The large text title that will display for the section.
     - **sectionHelpMessage:** A description about the section that can help the user understand what it is used for and how to fill out the fields
+    - **docLinkLabel:** An optional field that is the text that displays next to documentation help link.
+    - **docLink:** The optional link that the docLinkLabel will direct to if clicked.
       - **key:** The name of the configuration item as it is referenced in code.
       - **label:** The name of the configuration item as it appears in the UI.
       - **required** (Optional): Set to 'false' by default. Valid values are 'true' or 'false.' You must populate required configuration items in the IDN source configuration wizard before continuing.


### PR DESCRIPTION
This adds documentation for the new password change command, and also adds the new fields added to the connector descriptions that allows for a documentation link to be added to the source.