### PR TITLE
Update build_map_rule.md

### DIFF
--- a/products/idn/docs/identity-now/rules/cloud-rules/build_map_rule.md
+++ b/products/idn/docs/identity-now/rules/cloud-rules/build_map_rule.md
@@ -22,7 +22,7 @@ This rule runs in the cloud, but it's really a connector rule because it execute
 
 ## Execution
 
-- **Cloud Execution** - This rule executes in the IdentityNow cloud and it has read-only access to IdentityNow data models, but it doesn't have access to on-premise sources or connectors.
+- **Cloud Execution** - This rule executes in the IdentityNow cloud but it has no access to IdentityNow data models and it doesn't have access to on-premise sources or connectors.
 - **Logging** - Logging statements are currently only visible to SailPoint personnel.
 
 ![Rule Execution](../img/cloud_execution.png)

--- a/products/idn/docs/identity-now/rules/cloud-rules/build_map_rule.md
+++ b/products/idn/docs/identity-now/rules/cloud-rules/build_map_rule.md
@@ -22,7 +22,7 @@ This rule runs in the cloud, but it's really a connector rule because it execute
 
 ## Execution
 
-- **Cloud Execution** - This rule executes in the IdentityNow cloud but it has no access to IdentityNow data models and it doesn't have access to on-premise sources or connectors.
+- **Cloud Execution** - This rule executes in the IdentityNow cloud, and has read-only access to the records from the Delimited File being imported. However, it doesn't have access to on-premise sources or connectors.
 - **Logging** - Logging statements are currently only visible to SailPoint personnel.
 
 ![Rule Execution](../img/cloud_execution.png)


### PR DESCRIPTION
it seems buildmap can´t leverage sailpoint.rule (getIdentityById, etc) to get identity data, just like other connector rules