### PR TITLE
Fix heading level of Delete section in connectors.md

### DIFF
--- a/products/idn/tools/cli/connectors.md
+++ b/products/idn/tools/cli/connectors.md
@@ -110,7 +110,7 @@ sail conn validate -c [connectorID]
 
 You can pass in a `-r` flag to run the command as read-only, or you can run a full suite of read/write tests. 
 
-## Delete connector
+### Delete connector
 
 To delete a connector, run this command:
 


### PR DESCRIPTION
The "Delete connector" section appears larger as it is using the wrong heading level.  This change reduces the heading level to match the other sections.