### PR TITLE
Add missing line in connector-spec/index.md

### DIFF
--- a/products/idn/docs/identity-now/saas-connectivity/connector-spec/index.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-spec/index.md
@@ -40,6 +40,7 @@ The following describes in detail the different fields in the connector spec:
     - **sectionHelpMessage:** A description about the section that can help the user understand what it is used for and how to fill out the fields
     - **docLinkLabel:** An optional field that is the text that displays next to documentation help link.
     - **docLink:** The optional link that the docLinkLabel will direct to if clicked.
+    - **items:** The array of input fields for the menu item
       - **key:** The name of the configuration item as it is referenced in code.
       - **label:** The name of the configuration item as it appears in the UI.
       - **required** (Optional): Set to 'false' by default. Valid values are 'true' or 'false.' You must populate required configuration items in the IDN source configuration wizard before continuing.


### PR DESCRIPTION
The sourceConfig section in the connector-spec.json specifications is misleading. It appears that the input field specs (textarea, radio, etc) must be specified in docLinks, which is incorrect. It should be included in the "items" sub-array.