### PR TITLE
added docs to SaaS Connectivity for initial value feature in connector spec

### DIFF
--- a/products/idn/docs/identity-now/saas-connectivity/connector-spec/index.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-spec/index.md
@@ -30,7 +30,7 @@ The following describes in detail the different fields in the connector spec:
   - For example, the stdAccountRead command input is the StdAccountReadInput. if you select keyType as “simple,” then the StdAccountReadInput.key will be the type SimpleKey.
 
 - **commands:** The list of commands the connector supports. A full list of available commands can be found [here](../connector-commands/index.md).
-
+- **[sourceConfigInitialValues](./connector-spec/initial-value):** Key value pair of source config item keys and the default value that should be associated with them.
 - **sourceConfig** A list of configuration items you must provide when you create a source in IDN. The order of these items is preserved in the UI.
   - **type:** This is always “menu” - it indicates a new menu for the sidebar. You can have multiple sections defined for complex connector configurations
   - **label:** This label indicates the text that will show up on the sidebar in IDN

--- a/products/idn/docs/identity-now/saas-connectivity/connector-spec/initialValue.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-spec/initialValue.md
@@ -11,7 +11,7 @@ tags: ['Connectivity', 'Connector Spec']
 
 ## How to use the sourceConfigInitialValues in the connector spec
 
-If you want to prepopulate a field in the connector spec configuration with an initial value, you can use the `sourceConfigInitialValues` field in the connector spec to specify the prepopulated value. This can be used across all items. All you need to provide is the key of the item and the item's corresponding default value. This is a simple example using a textbox:
+If you want to prepopulate a field in the connector spec configuration with an initial value, you can use the `sourceConfigInitialValues` field in the connector spec to specify the prepopulated value. This can be used across all items. All you need to provide is the item's key and its corresponding default value. This is a simple example using a textbox:
 
 ```json
 "sourceConfigInitialValues": {

--- a/products/idn/docs/identity-now/saas-connectivity/connector-spec/initialValue.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-spec/initialValue.md
@@ -1,0 +1,44 @@
+---
+id: connector-spec-initial-value
+title: Initial Value
+pagination_label: Initial Value
+sidebar_label: Initial Value
+keywords: ['connectivity', 'connectors','connector-spec', 'sourceConfigInitialValues']
+description: Details on using the sourceConfigInitialValues field
+slug: /docs/saas-connectivity/connector-spec/initial-value
+tags: ['Connectivity', 'Connector Spec']
+---
+
+## How to use the sourceConfigInitialValues in the connector spec
+
+If you have a field in the connector spec configuration that you want to be pre-populated with an initial value, you can use the sourceConfigInitialValues in the connector spec to specify them. This can be utilized across all items, all you need to provide is the key of the item and the corrisponding default value for the item. A simple example using a textbox is shown below.
+
+```json
+"sourceConfigInitialValues": {
+    // Note that the key `airtableURL` is also the key of the item the initial value is provided for
+    "airtableURL": "https://api.airtable.com/v0"
+},
+"sourceConfig": [
+    {
+        "type": "menu",
+        "label": "Configuration",
+        "items": [
+            {
+
+                "type": "section",
+                "sectionTitle": "Authentication",
+                "sectionHelpMessage": "Provide the parameters to connect with the airtable worksheet.",
+                "items": [
+                    {
+                        // The key is what you use to assign initial values to the spec
+                        "key": "airtableURL",
+                        "label": "airtable url",
+                        "required": true,
+                        "type": "text"
+                    }
+                ]
+            }
+        ]
+    }
+]
+```

--- a/products/idn/docs/identity-now/saas-connectivity/connector-spec/initialValue.md
+++ b/products/idn/docs/identity-now/saas-connectivity/connector-spec/initialValue.md
@@ -4,14 +4,14 @@ title: Initial Value
 pagination_label: Initial Value
 sidebar_label: Initial Value
 keywords: ['connectivity', 'connectors','connector-spec', 'sourceConfigInitialValues']
-description: Details on using the sourceConfigInitialValues field
+description: How to use the sourceConfigInitialValues field
 slug: /docs/saas-connectivity/connector-spec/initial-value
 tags: ['Connectivity', 'Connector Spec']
 ---
 
 ## How to use the sourceConfigInitialValues in the connector spec
 
-If you have a field in the connector spec configuration that you want to be pre-populated with an initial value, you can use the sourceConfigInitialValues in the connector spec to specify them. This can be utilized across all items, all you need to provide is the key of the item and the corrisponding default value for the item. A simple example using a textbox is shown below.
+If you want to prepopulate a field in the connector spec configuration with an initial value, you can use the `sourceConfigInitialValues` field in the connector spec to specify the prepopulated value. This can be used across all items. All you need to provide is the key of the item and the item's corresponding default value. This is a simple example using a textbox:
 
 ```json
 "sourceConfigInitialValues": {


### PR DESCRIPTION
This adds the documentation to guide a user on how they can create an initial value (default) for config fields that are provided in the connector specification file