### PR TITLE
Remove transform preview

### DIFF
--- a/products/idn/tools/cli/transforms.md
+++ b/products/idn/tools/cli/transforms.md
@@ -29,10 +29,6 @@ To create, manage, and test transforms with the CLI, you can use these commands:
   - [Download transforms](#download-transforms)
   - [Create transform](#create-transform)
   - [Update transform](#update-transform)
-  - [Preview transform](#preview-transform)
-    - [Explicit input](#explicit-input)
-    - [Implicit input](#implicit-input)
-    - [Output](#output)
   - [Delete transform](#delete-transform)
 
 ## List transforms
@@ -78,57 +74,6 @@ sail transform update -f transform.json
 ```
 
 A common workflow is to first download the transforms, then make edits to the transform file, and then use the update command to save those edits in IDN.
-
-## Preview transform
-
-You can use the preview command to view a preview of the final output of a transform, using real account data from IDN. This command is safe to use when you are testing - it does not modify account or identity details in IDN. 
-
-You can preview both transforms with [explicit input](#explicit-input) and transforms with [implicit input](#implicit-input) determined by their identity profile mappings in IDN. 
-
-### Explicit input
-
-Transforms that use "explicit input" have direct references in their specifications to the account attributes the transforms will apply to. These transforms require additional flags: 
-
-- `-i` The identity profile ID to use for the preview. You can find the ID of the identity profile you are interested in by using the [Identity Profiles List](/idn/api/v3/list-identity-profiles) endpoint.
-- `-a` The name of the identity attribute to apply the transform to. This depends on the identity profile's available attributes.
-
-To preview an "explicit" input transform, run your command like this example: 
-
-```shell
-sail transform preview -i 2c91808876628b6201767b4bfea61dbb -a department -f transform.json
-```
-
-This example previews the output of a transform that will convert a specific identity's department name based on the details in the "transform.json" file. 
-
-### Implicit input
-
-Transforms that use "implicit input"* rely on the identity profile mapping in IDN to determine which account attribute to apply the transform to. These transforms require additional flags.
-
-- `--implicit` This indicates that the transform uses implicit input. It does not specify an account attribute directly in the JSON.
-- `-n <transform-name>` The name of the transform. The transform must be saved in IDN before you run this command.
-
-To preview an "implicit" input transform, run your command like this example: 
-
-```shell
-sail transform preview -i 2c91808876628b6201767b4bfea61dbb -a department -n ToUpper --implicit
-```
-
-This example previews the output of a transform that will convert a specific identity's incoming lowercased department name to an uppercased name based on identity profile mapping in IDN. 
-
-### Output
-
-The preview command produces this output: 
-
-```shell
-Original value: adam.archer
-Transformed value: ADAM.ARCHER
-```
-
-This is an example of a preview for a transform that is converting incoming lowercased account names into uppercased account names. 
-
-The `Original value` is the value of the identity attribute at the time of the last identity refresh. It is not the value of the account attribute as it currently exists on the source. The value may already have been transformed if the identity profile mapping has a transform mapped to the attribute.
-
-The `Transformed value` is a result of a change to the account attribute, according to the transform specification. This is what the identity attribute will become if you use this transform in the identity profile.
 
 ## Delete transform
 


### PR DESCRIPTION
With the CC APIs being deprecated, we have to remove the preview transform command until a suitable replacement is made available.