### PR TITLE
Correct formating

### DIFF
--- a/docs/extensibility/transforms/operations/date-math.md
+++ b/docs/extensibility/transforms/operations/date-math.md
@@ -90,7 +90,7 @@ Some examples of expressions are:
 
     - `true` indicates the transform rounds up (i.e., truncate the fractional date/time component indicated and then add one unit of that component).
     - `false` indicates the transform rounds down (i.e., truncate the fractional date/time component indicated).
-    - `input` - This is an optional attribute that can explicitly define the input data passed into the transform logic. If no input is provided, the transform takes its input from the source and attribute combination configured with the UI.
+  - **input** - This is an optional attribute that can explicitly define the input data passed into the transform logic. If no input is provided, the transform takes its input from the source and attribute combination configured with the UI.
 
 ## Examples
 


### PR DESCRIPTION
Correct attribute formatting - currently 'input' is listed as a value for 'roundUp'. 
This correctly lists 'input' as a separate optional attribute. 