### PR TITLE
Update idn_rule_utility.md

### DIFF
--- a/docs/extensibility/rules/idn_rule_utility.md
+++ b/docs/extensibility/rules/idn_rule_utility.md
@@ -191,7 +191,7 @@ sailpoint.object.Identity identity = plan.getIdentity();
 String sAMAccountName = identity.getAttribute("adUsername");
 
 sailpoint.rule.Identity foundIdentity = idn.getIdentityById("uid");
-String email = foundIdentity.getAttribute("email");
+String email = foundIdentity.getEmail();
 ```
 
 The below section provides a full accounting of the methods available to rule writers using the IdnRuleUtil class:


### PR DESCRIPTION
In this example of how to differentiate between the two classes of type identity,  an incorrect method for the sailpoint.rule.Identity class is referenced:

sailpoint.rule.Identity foundIdentity = idn.getIdentityById("uid"); String email = foundIdentity.getAttribute("email");

It should be changed to:

sailpoint.rule.Identity foundIdentity = idn.getIdentityById("uid"); String email = foundIdentity.getEmail();

Looks like it got changed when this content was copied from  https://community.sailpoint.com/t5/IdentityNow-Wiki/Using-IDNRuleUtil-as-a-Wrapper-for-Common-Rule-Operations/ta-p/201496