### PR TITLE
removed requirement that is not actually needed

### DIFF
--- a/docs/tools/cli/index.md
+++ b/docs/tools/cli/index.md
@@ -25,7 +25,6 @@ Learn how to use the SailPoint command line interface (CLI) in this guide.
 
 - [Start using the CLI](#start-using-the-cli)
 - [Contents](#contents)
-- [Requirements](#requirements)
 - [Get the CLI](#get-the-cli)
   - [Windows](#windows)
   - [MacOS](#macos)
@@ -41,9 +40,6 @@ Learn how to use the SailPoint command line interface (CLI) in this guide.
 - [Contribution](#contribution)
 - [Questions](#questions)
 
-## Requirements
-
-- Golang version 1.18 or above. You can download it [here](https://go.dev/dl/). You can run `go version` to check your version.
 
 ## Get the CLI
 


### PR DESCRIPTION
Noticed this requirement is listed in the getting started guide for the CLI, while it is required to build the CLI, it is not needed to install the CLI