### PR TITLE
Added ambassador program to navbar

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -33,6 +33,11 @@ module.exports = {
     },
     {
       position: 'left',
+      label: 'Ambassador Program',
+      to: 'https://developer.sailpoint.com/ambassadors/',
+    },
+    {
+      position: 'left',
       label: 'Discuss',
       to: 'https://developer.sailpoint.com/discuss/',
     },


### PR DESCRIPTION
The Ambassador program page is currently inaccessible from the navbar. I added a navbar item to navigate tohttps://developer.sailpoint.com/ambassadors/