### PR TITLE
Update index.md for code rules

### DIFF
--- a/docs/extensibility/rules/index.md
+++ b/docs/extensibility/rules/index.md
@@ -196,6 +196,41 @@ public static
 XMLObjectFactory
 Log4j
 Logger.getLogger​
+System.exit
+Runtime.
+server(
+ServerSocket
+ProcessBuilder
+exec(
+exit(
+ rm(
+getRuntime
+shutdownOnExit
+bg(
+cp(
+desktop(
+getBshPrompt
+mv(
+run(
+pathToFile
+editor(
+addClassPath
+bind(
+browseClass
+ cat(
+cd(
+classBrowser
+dir(
+dirname(
+frame(
+importCommands
+ load(
+makeWorkspace
+pwd(
+reloadClasses
+setClassPath
+source(
+sourceRelative
 ```
 
 Note that the earlier code fragments are not allowed within [connector-executed rules](./connector-rules/index.md#supported-connector-rules) because they are not valid at the connector level. They will, for a short time, still be allowed for pre-existing [cloud-executed rules](./cloud-rules/index.md) as a review exception. However, any new rules using these constructs will be returned to the submitter, and the submitter will be asked to rewrite the rule, using the [ISC Rule Utility](./idn_rule_utility.md) helper methods instead:


### PR DESCRIPTION
As part of IDNARSENAL-21252, code restrictions were added for native bean shell execution. 

Therefore the documentation needs to be updated with those restricted keywords.