### PR TITLE
Update saas-configuration.mdx

### DIFF
--- a/docs/extensibility/configuration-management/saas-configuration.mdx
+++ b/docs/extensibility/configuration-management/saas-configuration.mdx
@@ -54,6 +54,10 @@ This document is intended for technically proficient administrators, implementer
 
 The available supported objects are also available via REST API! See List Configuration Objects in the **API Reference** section of this document.
 
+:::tip
+
+Source passwords, secret token or other sensitive data is not exported. Those need to be re-added after importing
+
 :::
 
 **Rule Import and Export -** Rules can be exported from one tenant and imported into another. Cloud rules have already been reviewed and installed in other tenants, and connector rules do not require a rule review. During the import and export process, rules cannot be changed in the migration process because these are validated by the usage of `jwsHeader` and `jwsSignature` in the object.


### PR DESCRIPTION
config hub and/or sp-config are not 100% reliable on backup or export sources when talking about password. It seems it was designed to not export it, which is fine.

but caveat is that it still exports some source passwords... https://sailpoint.atlassian.net/issues/IDNETN-8101?jql=text%20~%20%22sp-config%20password%22%20ORDER%20BY%20updated%20DESC (this ticket is still valid though, got a customer with that situation last month).

still it might be good to explain they should not expect passwords to come in exports or backups