### PR TITLE
Update display-name.md

### DIFF
--- a/docs/extensibility/transforms/operations/display-name.md
+++ b/docs/extensibility/transforms/operations/display-name.md
@@ -21,7 +21,7 @@ The displayName generator transform is intended for using Preferred Name over Gi
 ```json
 {
   "name": "displayName",
-  "type": "Display Name Transform"
+  "type": "displayName"
 }
 ```
 


### PR DESCRIPTION
looks like a typo in the example provided in the documentation. Also the attributes also seems to be an mandatory field. For example below transform worked fine for me but the one provided in the example does not work 

{
    "name": "test displayname",
    "type": "displayName",
    "attributes": {
        "input": {
            "type": "static",
            "attributes": {
                "value": "test Value"
            }
        }
    },
    "internal": false
}