### PR TITLE
fix crypto-js version from 4.1.1 to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7655,7 +7655,7 @@
         "@reduxjs/toolkit": "^1.7.1",
         "clsx": "^1.1.1",
         "copy-text-to-clipboard": "^3.1.0",
-        "crypto-js": "^4.1.1",
+        "crypto-js": "^4.2.0",
         "docusaurus-plugin-openapi-docs": "^3.0.1",
         "docusaurus-plugin-sass": "^0.2.3",
         "file-saver": "^2.0.5",


### PR DESCRIPTION
update cyrpto-js version to 4.2.0 fix Dependabot alert. 