### PR TITLE
Update build_map_rule.md

### DIFF
--- a/docs/extensibility/rules/cloud-rules/build_map_rule.md
+++ b/docs/extensibility/rules/cloud-rules/build_map_rule.md
@@ -29,18 +29,86 @@ This rule manipulates raw input data provided by the rows and columns in a file 
 
 | Argument | Type | Purpose |
 | --- | --- | --- |
-| col | java.util.List | Ordered list of the column names from the file’s header records or specified columns list. |
+| cols | java.util.List | Ordered list of the column names from the file’s header records or specified columns list. |
 | record | java.util.List | Ordered list of the values for the current record, parsed based on the specified delimiter. |
 | application | System.Collections.Hashtable | Map of the application configuration. |
 | schema | sailpoint.object.Schema | Reference to the schema object for the delimited file source being read. |
 
-## Template
+## Connector Rule JSON Template
+This template is used for the connector rule development process which is supported for the delimited file connector. Note the BeanShell code is escaped in the $.sourceCode.script attribute. The example, unescaped and formatted for readability, follows.
+
+```JSON
+{
+    "name": "Sample BuildMapRule",
+    "type": "BuildMap",
+    "signature": {
+        "input": [
+            {
+                "name": "col",
+                "description": "An ordered list of the column names from the file’s header record or specified Columns list.",
+                "type": null
+            },
+            {
+                "name": "record",
+                "description": "An ordered list of the values for the current record (parsed based on the specified delimiter)",
+                "type": null
+            },
+            {
+                "name": "application",
+                "description": "The source object sent to the connector from IdentityNow.",
+                "type": null
+            },
+            {
+                "name": "schema",
+                "description": "A reference to the Schema object for the Delimited File source being read.",
+                "type": null
+            }
+        ],
+        "output": null
+    },
+    "sourceCode": {
+        "version": "1.0",
+        "script": "import sailpoint.connector.DelimitedFileConnector;\n\nMap map = DelimitedFileConnector.defaultBuildMap( cols, record );\nString access = (String) map.get( \"access\" );\nString permission = (String) map.get( \"permission\" );\n\nif ( access != null && permission != null ) {\n     map.remove(\"access\");\n     map.remove(\"permission\");\n     map.put(\"access\", access + \" - \" + permission);\n}\nreturn map;"
+    },
+    "attributes": {
+        "sourceVersion": "1.0"
+    },
+    "description": "This basic rule performs the combines 2 values into a single attribute."
+}
+```
+## Connector Rule Example
+This is the unescaped BeanShell code from the $.sourceCode.script attribute above.
+```java
+ import sailpoint.connector.DelimitedFileConnector;
+
+ Map map = DelimitedFileConnector.defaultBuildMap( cols, record );
+ String access = (String) map.get( "access" );
+ String permission = (String) map.get( "permission" );
+
+ if ( access != null && permission != null ) {
+      map.remove("access");
+      map.remove("permission");
+      map.put("access", access + " - " + permission);
+ }
+ return map;
+```
+## Cloud Rule XML Template
+This template is used for the cloud rule deployement process which is NOT requried for buildmap rules but is still supported. 
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE Rule PUBLIC "sailpoint.dtd" "sailpoint.dtd">
 <Rule name="Example Rule" type="BuildMap">
   <Description>Describe your rule here.</Description>
+  <Signature>
+    <Inputs>
+      <Argument name="log"/>
+      <Argument name="cols" type="List"/>
+      <Argument name="record" type="List"/>
+      <Argument name="application"/>
+      <Argument name="schema"/>
+    </Inputs>
+  </Signature>
   <Source><![CDATA[
 
   // Add your logic here.
@@ -49,18 +117,27 @@ This rule manipulates raw input data provided by the rows and columns in a file 
 </Rule>
 ```
 
-## Example
+## Cloud Rule Example
 
 ```java
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE Rule PUBLIC "sailpoint.dtd" "sailpoint.dtd">
 <Rule name="Example Rule" type="BuildMap">
   <Description>This basic rule performs the combines 2 values into a single attribute.</Description>
+  <Signature>
+    <Inputs>
+      <Argument name="log"/>
+      <Argument name="cols" type="List"/>
+      <Argument name="record" type="List"/>
+      <Argument name="application"/>
+      <Argument name="schema"/>
+    </Inputs>
+  </Signature>
   <Source><![CDATA[
 
      import sailpoint.connector.DelimitedFileConnector;
 
-     Map map = DelimitedFileConnector.defaultBuildMap( col, record );
+     Map map = DelimitedFileConnector.defaultBuildMap( cols, record );
      String access = (String) map.get( "access" );
      String permission = (String) map.get( "permission" );
 

--- a/docs/extensibility/rules/cloud-rules/build_map_rule.md
+++ b/docs/extensibility/rules/cloud-rules/build_map_rule.md
@@ -44,7 +44,7 @@ This template is used for the connector rule development process which is suppor
     "signature": {
         "input": [
             {
-                "name": "col",
+                "name": "cols",
                 "description": "An ordered list of the column names from the file’s header record or specified Columns list.",
                 "type": null
             },


### PR DESCRIPTION
The rule is provided a cols attribute, not a col attribute. The example will fail as documented.

example template and code for the connector rule development option, allowed for delimited file buildmap rules, has been included.

For the cloud connector rule development process, the past example fails as the signature definition is required. I have added the minimum signature required based on a rule deploy done last week.