### PR TITLE
Feature/oauth flow changes

### DIFF
--- a/src/pages/sailapps.js
+++ b/src/pages/sailapps.js
@@ -36,9 +36,14 @@ function SailApps() {
 
     setIsSending(true);
     try {
-      await sendCode(siteConfig.customFields.CMS_APP_API_ENDPOINT, authCode, state);
-      setIsConfirmed(true);
-      setSendResult('Your application can now access your data, you can close this window');
+      const result = await sendCode(siteConfig.customFields.CMS_APP_API_ENDPOINT, authCode, state);
+      // Check if the response indicates success
+      if (result && result.message === 'Token added successfully') {
+        setIsConfirmed(true);
+        setSendResult('Your application can now access your data, you can close this window');
+      } else {
+        setSendResult('Authentication failed: Unexpected response from server');
+      }
     } catch (error) {
       setSendResult(`Error sending authentication: ${error.message}`);
     }

--- a/src/services/SailAppsService.ts
+++ b/src/services/SailAppsService.ts
@@ -8,9 +8,18 @@ export async function sendCode(gatewayUrl: string, code: string, state: string) 
       },
       body: JSON.stringify({ code, state }),
     });
+    
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ message: 'Unknown error' }));
+      throw new Error(errorData.message || `HTTP ${response.status}: ${response.statusText}`);
+    }
+    
     return await response.json();
   } catch (error) {
-    return [];
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error('Network error occurred');
   }
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -242,14 +242,20 @@ Resources:
         ReadCapacityUnits: 20
         WriteCapacityUnits: 2
   SailAppsAuth:
-    Type: AWS::Serverless::SimpleTable
+    Type: AWS::DynamoDB::Table
     Properties:
-      PrimaryKey:
-        Name: id
-        Type: String
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
       ProvisionedThroughput:
         ReadCapacityUnits: 20
         WriteCapacityUnits: 2
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
   # S3 Bucket to host single page app website
   DeveloperSailpointWebSiteBucket:
     Type: "AWS::S3::Bucket"

--- a/template.yaml
+++ b/template.yaml
@@ -159,6 +159,10 @@ Resources:
           AUTH_TOKENS_TABLE: !Ref SailAppsAuth
           # Make DynamoDB endpoint accessible as environment variable from function code during execution
           ENDPOINT_OVERRIDE: ""
+          # OAuth configuration
+          OAUTH_CLIENT_ID: sailpoint-cli
+          OAUTH_DEV_REDIRECT_URL: http://localhost:4200/sailapps
+          OAUTH_REDIRECT_URL: https://developer.sailpoint.com/sailapps
   JSONPathGoFunction:
     Type: AWS::Serverless::Function
     Metadata:


### PR DESCRIPTION
This PR adds the following:
TTL to the entries so they atomically expire and also deletes them once the token is retrieved.  
It also fixes a bug where the lambda would be created without the environment variables that are needed for it to function properly
It fixes a bug on the UI where errors were not being passed to the user so even if the web request fails the user thinks it went through properly