### PR TITLE
fix(before-after-operation-rules): replace Invoke-Expression with call operator to prevent code interpretation issues

### DIFF
--- a/docs/extensibility/rules/connector-rules/before_after_operation_rule.md
+++ b/docs/extensibility/rules/connector-rules/before_after_operation_rule.md
@@ -102,8 +102,7 @@ Try{
     }
 
     #Call the client script
-    $command = -join ($command, " -requestString '$requestAsString'")
-    Invoke-Expression $command
+    & $command -requestString $requestAsString
 
 }Catch{
  $ErrorMessage = $_.Exception.Message


### PR DESCRIPTION
Replaced the use of `Invoke-Expression` in the ConnectorAfterCreate rule with the PowerShell call operator `&`. This change prevents special characters in the `$requestAsString` (such as quotes, pipes, or ampersands) from being misinterpreted as code, eliminating syntax errors and potential injection risks during execution.

The update improves reliability and security when handling complex or user-provided input in CreateAfterRule PowerShell scripts.

Currently SailPoint already has lot of clients facing issues with Invoke-Expression, and a significant amount of users are already using "&" to invoke this command (check https://github.com/sailpoint/identitynow-services-config to confirm the usage)