### PR TITLE
fix(security):Add Google Analytics to CSP [DEVREL-2402]

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -86,7 +86,7 @@ const config: Config = {
       { name: 'twitter:image', content: 'https://developer.sailpoint.com/img/SailPoint-Logo-OG.png' },
 
       // Content Security Policy
-      { 'http-equiv': 'Content-Security-Policy', content: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://p.typekit.net https://use.typekit.net; img-src 'self' data: https: http:; font-src 'self' data: https://cdn.jsdelivr.net https://use.typekit.net; connect-src 'self' http://localhost:3000 https://*.algolia.net https://*.algolianet.com https://www.googletagmanager.com https://developer.sailpoint.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube.com;" },
+      { 'http-equiv': 'Content-Security-Policy', content: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://p.typekit.net https://use.typekit.net; img-src 'self' data: https: http:; font-src 'self' data: https://cdn.jsdelivr.net https://use.typekit.net; connect-src 'self' http://localhost:3000 https://*.algolia.net https://*.algolianet.com https://www.googletagmanager.com https://www.google.com https://analytics.google.com https://developer.sailpoint.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube.com https://play.vidyard.com;" },
     ],
     algolia: {
       appId: 'TB01H1DFAM',

--- a/template.yaml
+++ b/template.yaml
@@ -360,7 +360,7 @@ Resources:
         Comment: "Security headers for developer.sailpoint.com including CSP"
         SecurityHeadersConfig:
           ContentSecurityPolicy:
-            ContentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://p.typekit.net https://use.typekit.net; img-src 'self' data: https: http:; font-src 'self' data: https://cdn.jsdelivr.net https://use.typekit.net; connect-src 'self' http://localhost:3000 https://*.algolia.net https://*.algolianet.com https://www.googletagmanager.com https://developer.sailpoint.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube.com;"
+            ContentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://p.typekit.net https://use.typekit.net; img-src 'self' data: https: http:; font-src 'self' data: https://cdn.jsdelivr.net https://use.typekit.net; connect-src 'self' http://localhost:3000 https://*.algolia.net https://*.algolianet.com https://www.googletagmanager.com https://www.google.com https://analytics.google.com https://developer.sailpoint.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube.com https://play.vidyard.com;"
             Override: true
 Parameters:
   AuthUsername:


### PR DESCRIPTION
- Add play.vidyard.com to frame-src for Vidyard video embeds
- Add www.google.com to connect-src for Google Ads tracking
- Add analytics.google.com to connect-src for Google Analytics

Fixes additional CSP violations discovered during testing:
- Vidyard video embeds blocked
- Google Analytics tracking blocked
- Google Ads conversion tracking blocked