### PR TITLE
Add new CIEM event trigger documentation

### DIFF
--- a/docs/extensibility/event-triggers/available/ciem-auto-include-scope-setting-changed.md
+++ b/docs/extensibility/event-triggers/available/ciem-auto-include-scope-setting-changed.md
@@ -1,0 +1,60 @@
+---
+id: ciem-auto-include-scope-setting-changed
+title: CIEM Auto-Include Scope Setting Changed
+pagination_label: CIEM Auto-Include Scope Setting Changed
+sidebar_label: CIEM Auto-Include Scope Setting Changed
+sidebar_class_name: ciemAutoIncludeScopeSettingChanged
+keywords: ['event', 'trigger', 'ciem', 'scope', 'auto-include', 'setting', 'available']
+description: Fires after a user enables or disables the Auto-Include Scope setting for a CIEM source.
+slug: /extensibility/event-triggers/triggers/ciem-auto-include-scope-setting-changed
+tags: ['Event Triggers', 'Available Event Triggers', 'Fire and Forget']
+---
+
+## Event Context
+
+A user has disabled or enabled the Auto-Include Scope functionality for a source. When auto-include scope is disabled, SailPoint CIEM will not check for newly added AWS accounts, Azure subscriptions, or GCP projects.
+
+You can use a JSONPath filter expression to narrow down the circumstances under which your workflow will be triggered.
+
+This trigger only fires if you have the CIEM service.
+
+This is an example input from this trigger:
+
+```json
+{
+  "$ref": "#/definitions/record:AutoIncludeScopeSettingChanged",
+  "definitions": {
+    "record:AutoIncludeScopeSettingChanged": {
+      "additionalProperties": true,
+      "properties": {
+        "event": {
+          "type": "string"
+        },
+        "identityDisplayName": {
+          "type": "string"
+        },
+        "identityId": {
+          "type": "string"
+        },
+        "sourceIscId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "sourceNativeId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}
+```
+
+## Additional Information and Links
+
+- **Trigger Type**: [FIRE_AND_FORGET](../trigger-types.md#fire-and-forget)

--- a/docs/extensibility/event-triggers/available/ciem-new-scope-detected.md
+++ b/docs/extensibility/event-triggers/available/ciem-new-scope-detected.md
@@ -1,0 +1,86 @@
+---
+id: ciem-new-scope-detected
+title: CIEM New Scope Detected
+pagination_label: CIEM New Scope Detected
+sidebar_label: CIEM New Scope Detected
+sidebar_class_name: ciemNewScopeDetected
+keywords: ['event', 'trigger', 'ciem', 'scope', 'detected', 'available']
+description: Fires after a new AWS account, Azure subscription, or GCP project is detected by SailPoint CIEM.
+slug: /extensibility/event-triggers/triggers/ciem-new-scope-detected
+tags: ['Event Triggers', 'Available Event Triggers', 'Fire and Forget']
+---
+
+## Event Context
+
+A new AWS account, Azure subscription, or GCP project was detected by SailPoint CIEM.
+
+You can use a JSONPath filter expression to narrow down the circumstances under which your workflow will be triggered.
+
+This trigger only fires if you have the CIEM service.
+
+This is an example input from this trigger:
+
+```json
+{
+  "$ref": "#/definitions/record:NewScopeDetected",
+  "definitions": {
+    "record:NewScopeDetected": {
+      "additionalProperties": true,
+      "properties": {
+        "event": {
+          "type": "string"
+        },
+        "org": {
+          "type": "string"
+        },
+        "scopesDiscovered": {
+          "items": {
+            "$ref": "#/definitions/record:Scope"
+          },
+          "type": "array"
+        },
+        "scopesEnabled": {
+          "type": "boolean"
+        },
+        "sourceIscId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "sourceNativeId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "total": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "truncated": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "record:Scope": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "nativeId": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "nativeId"],
+      "type": "object"
+    }
+  }
+}
+```
+
+## Additional Information and Links
+
+- **Trigger Type**: [FIRE_AND_FORGET](../trigger-types.md#fire-and-forget)

--- a/docs/extensibility/event-triggers/available/ciem-scope-selection-changed.md
+++ b/docs/extensibility/event-triggers/available/ciem-scope-selection-changed.md
@@ -1,0 +1,86 @@
+---
+id: ciem-scope-selection-changed
+title: CIEM Scope Selection Changed
+pagination_label: CIEM Scope Selection Changed
+sidebar_label: CIEM Scope Selection Changed
+sidebar_class_name: ciemScopeSelectionChanged
+keywords: ['event', 'trigger', 'ciem', 'scope', 'selection', 'available']
+description: Fires after a user changes the scope selection for a CIEM source.
+slug: /extensibility/event-triggers/triggers/ciem-scope-selection-changed
+tags: ['Event Triggers', 'Available Event Triggers', 'Fire and Forget']
+---
+
+## Event Context
+
+A user has changed the scope selection for a source. If a cloud scope is deselected, SailPoint CIEM will no longer check for changes to that specific AWS account, Azure subscription, or GCP project.
+
+You can use a JSONPath filter expression to narrow down the circumstances under which your workflow will be triggered.
+
+This trigger only fires if you have the CIEM service.
+
+This is an example input from this trigger:
+
+```json
+{
+  "$ref": "#/definitions/record:ScopeSelectionChanged",
+  "definitions": {
+    "record:Scope": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "nativeId": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "nativeId"],
+      "type": "object"
+    },
+    "record:ScopeSelectionChanged": {
+      "additionalProperties": true,
+      "properties": {
+        "event": {
+          "type": "string"
+        },
+        "identityDisplayName": {
+          "type": "string"
+        },
+        "identityId": {
+          "type": "string"
+        },
+        "scopesModified": {
+          "items": {
+            "$ref": "#/definitions/record:Scope"
+          },
+          "type": "array"
+        },
+        "sourceIscId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "sourceNativeId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "total": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "truncated": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  }
+}
+```
+
+## Additional Information and Links
+
+- **Trigger Type**: [FIRE_AND_FORGET](../trigger-types.md#fire-and-forget)

--- a/static/api-specs/idn/beta/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
+++ b/static/api-specs/idn/beta/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
@@ -1,0 +1,32 @@
+title: CIEM Auto-Include Scope Setting Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: AutoIncludeScopeSettingChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the Auto-Include Scope setting.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the Auto-Include Scope setting.
+    example: 2c7180a46faadee4016fb4e018c20648
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose Auto-Include Scope setting was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the Auto-Include Scope setting was changed.
+    example: "2024-03-29T22:01:50.474Z"

--- a/static/api-specs/idn/beta/schemas/trigger/example-input/CiemNewScopeDetected.yaml
+++ b/static/api-specs/idn/beta/schemas/trigger/example-input/CiemNewScopeDetected.yaml
@@ -1,0 +1,59 @@
+title: CIEM New Scope Detected
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: NewScopeDetected
+  org:
+    type: string
+    description: The ISC tenant (org) where the event occurred.
+    example: acme-sb
+  scopesDiscovered:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) that were newly discovered by SailPoint CIEM.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the discovered cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  scopesEnabled:
+    type: boolean
+    description: Whether the newly discovered scopes have been automatically enabled for monitoring by SailPoint CIEM.
+    example: true
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) that the scopes were detected on.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the new scope(s) were detected by SailPoint CIEM.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes discovered in this event.
+    example: 3
+  truncated:
+    type: boolean
+    description: Whether the `scopesDiscovered` list was truncated because the total number of discovered scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/beta/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
+++ b/static/api-specs/idn/beta/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
@@ -1,0 +1,59 @@
+title: CIEM Scope Selection Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: ScopeSelectionChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the scope selection.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the scope selection.
+    example: 2c7180a46faadee4016fb4e018c20648
+  scopesModified:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) whose selection was changed for this CIEM source.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose scope selection was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the scope selection was changed.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes modified in this event.
+    example: 2
+  truncated:
+    type: boolean
+    description: Whether the `scopesModified` list was truncated because the total number of modified scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/beta/webhooks/ciem-auto-include-scope-setting-changed.yaml
+++ b/static/api-specs/idn/beta/webhooks/ciem-auto-include-scope-setting-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM auto-include scope setting changed
+  operationId: ciemAutoIncludeScopeSettingChangedEvent
+  description: >-
+    This event trigger fires when a user disables or enables the Auto-Include Scope functionality for a source. When auto-include scope is disabled, SailPoint CIEM will not check for newly added AWS accounts, Azure subscriptions, or GCP projects.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Auto-Include Scope Setting Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-auto-include-scope-setting-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml'

--- a/static/api-specs/idn/beta/webhooks/ciem-new-scope-detected.yaml
+++ b/static/api-specs/idn/beta/webhooks/ciem-new-scope-detected.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM new scope detected
+  operationId: ciemNewScopeDetectedEvent
+  description: >-
+    This event trigger fires when SailPoint CIEM detects a new AWS account, Azure subscription, or GCP project for a source.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM New Scope Detected](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-new-scope-detected).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemNewScopeDetected.yaml'

--- a/static/api-specs/idn/beta/webhooks/ciem-scope-selection-changed.yaml
+++ b/static/api-specs/idn/beta/webhooks/ciem-scope-selection-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM scope selection changed
+  operationId: ciemScopeSelectionChangedEvent
+  description: >-
+    This event trigger fires when a user changes the scope selection for a source. If a cloud scope is deselected, SailPoint CIEM will no longer check for changes to that specific AWS account, Azure subscription, or GCP project.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Scope Selection Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-scope-selection-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemScopeSelectionChanged.yaml'

--- a/static/api-specs/idn/sailpoint-api.beta.yaml
+++ b/static/api-specs/idn/sailpoint-api.beta.yaml
@@ -1186,6 +1186,12 @@ x-webhooks:
     $ref: './beta/webhooks/campaign-generated.yaml'
   CertificationSignedOff:
     $ref: './beta/webhooks/certification-signed-off.yaml'
+  CiemAutoIncludeScopeSettingChanged:
+    $ref: './beta/webhooks/ciem-auto-include-scope-setting-changed.yaml'
+  CiemNewScopeDetected:
+    $ref: './beta/webhooks/ciem-new-scope-detected.yaml'
+  CiemScopeSelectionChanged:
+    $ref: './beta/webhooks/ciem-scope-selection-changed.yaml'
   FormSubmitted:
     $ref: './beta/webhooks/form-submitted.yaml'
   IdentityAttributesChanged:

--- a/static/api-specs/idn/sailpoint-api.v2024.yaml
+++ b/static/api-specs/idn/sailpoint-api.v2024.yaml
@@ -1302,6 +1302,12 @@ x-webhooks:
     $ref: './v2024/webhooks/campaign-generated.yaml'
   CertificationSignedOff:
     $ref: './v2024/webhooks/certification-signed-off.yaml'
+  CiemAutoIncludeScopeSettingChanged:
+    $ref: './v2024/webhooks/ciem-auto-include-scope-setting-changed.yaml'
+  CiemNewScopeDetected:
+    $ref: './v2024/webhooks/ciem-new-scope-detected.yaml'
+  CiemScopeSelectionChanged:
+    $ref: './v2024/webhooks/ciem-scope-selection-changed.yaml'
   FormSubmitted:
     $ref: './v2024/webhooks/form-submitted.yaml'
   IdentityAttributesChanged:

--- a/static/api-specs/idn/sailpoint-api.v2025.yaml
+++ b/static/api-specs/idn/sailpoint-api.v2025.yaml
@@ -1388,6 +1388,12 @@ x-webhooks:
     $ref: './v2025/webhooks/campaign-generated.yaml'
   CertificationSignedOff:
     $ref: './v2025/webhooks/certification-signed-off.yaml'
+  CiemAutoIncludeScopeSettingChanged:
+    $ref: './v2025/webhooks/ciem-auto-include-scope-setting-changed.yaml'
+  CiemNewScopeDetected:
+    $ref: './v2025/webhooks/ciem-new-scope-detected.yaml'
+  CiemScopeSelectionChanged:
+    $ref: './v2025/webhooks/ciem-scope-selection-changed.yaml'
   FormSubmitted:
     $ref: './v2025/webhooks/form-submitted.yaml'
   IdentityAttributesChanged:

--- a/static/api-specs/idn/v2024/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
+++ b/static/api-specs/idn/v2024/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
@@ -1,0 +1,32 @@
+title: CIEM Auto-Include Scope Setting Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: AutoIncludeScopeSettingChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the Auto-Include Scope setting.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the Auto-Include Scope setting.
+    example: 2c7180a46faadee4016fb4e018c20648
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose Auto-Include Scope setting was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the Auto-Include Scope setting was changed.
+    example: "2024-03-29T22:01:50.474Z"

--- a/static/api-specs/idn/v2024/schemas/trigger/example-input/CiemNewScopeDetected.yaml
+++ b/static/api-specs/idn/v2024/schemas/trigger/example-input/CiemNewScopeDetected.yaml
@@ -1,0 +1,59 @@
+title: CIEM New Scope Detected
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: NewScopeDetected
+  org:
+    type: string
+    description: The ISC tenant (org) where the event occurred.
+    example: acme-sb
+  scopesDiscovered:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) that were newly discovered by SailPoint CIEM.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the discovered cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  scopesEnabled:
+    type: boolean
+    description: Whether the newly discovered scopes have been automatically enabled for monitoring by SailPoint CIEM.
+    example: true
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) that the scopes were detected on.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the new scope(s) were detected by SailPoint CIEM.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes discovered in this event.
+    example: 3
+  truncated:
+    type: boolean
+    description: Whether the `scopesDiscovered` list was truncated because the total number of discovered scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/v2024/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
+++ b/static/api-specs/idn/v2024/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
@@ -1,0 +1,59 @@
+title: CIEM Scope Selection Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: ScopeSelectionChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the scope selection.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the scope selection.
+    example: 2c7180a46faadee4016fb4e018c20648
+  scopesModified:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) whose selection was changed for this CIEM source.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose scope selection was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the scope selection was changed.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes modified in this event.
+    example: 2
+  truncated:
+    type: boolean
+    description: Whether the `scopesModified` list was truncated because the total number of modified scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/v2024/webhooks/ciem-auto-include-scope-setting-changed.yaml
+++ b/static/api-specs/idn/v2024/webhooks/ciem-auto-include-scope-setting-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM auto-include scope setting changed
+  operationId: ciemAutoIncludeScopeSettingChangedEvent
+  description: >-
+    This event trigger fires when a user disables or enables the Auto-Include Scope functionality for a source. When auto-include scope is disabled, SailPoint CIEM will not check for newly added AWS accounts, Azure subscriptions, or GCP projects.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Auto-Include Scope Setting Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-auto-include-scope-setting-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml'

--- a/static/api-specs/idn/v2024/webhooks/ciem-new-scope-detected.yaml
+++ b/static/api-specs/idn/v2024/webhooks/ciem-new-scope-detected.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM new scope detected
+  operationId: ciemNewScopeDetectedEvent
+  description: >-
+    This event trigger fires when SailPoint CIEM detects a new AWS account, Azure subscription, or GCP project for a source.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM New Scope Detected](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-new-scope-detected).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemNewScopeDetected.yaml'

--- a/static/api-specs/idn/v2024/webhooks/ciem-scope-selection-changed.yaml
+++ b/static/api-specs/idn/v2024/webhooks/ciem-scope-selection-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM scope selection changed
+  operationId: ciemScopeSelectionChangedEvent
+  description: >-
+    This event trigger fires when a user changes the scope selection for a source. If a cloud scope is deselected, SailPoint CIEM will no longer check for changes to that specific AWS account, Azure subscription, or GCP project.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Scope Selection Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-scope-selection-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemScopeSelectionChanged.yaml'

--- a/static/api-specs/idn/v2025/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
+++ b/static/api-specs/idn/v2025/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
@@ -1,0 +1,32 @@
+title: CIEM Auto-Include Scope Setting Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: AutoIncludeScopeSettingChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the Auto-Include Scope setting.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the Auto-Include Scope setting.
+    example: 2c7180a46faadee4016fb4e018c20648
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose Auto-Include Scope setting was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the Auto-Include Scope setting was changed.
+    example: "2024-03-29T22:01:50.474Z"

--- a/static/api-specs/idn/v2025/schemas/trigger/example-input/CiemNewScopeDetected.yaml
+++ b/static/api-specs/idn/v2025/schemas/trigger/example-input/CiemNewScopeDetected.yaml
@@ -1,0 +1,59 @@
+title: CIEM New Scope Detected
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: NewScopeDetected
+  org:
+    type: string
+    description: The ISC tenant (org) where the event occurred.
+    example: acme-sb
+  scopesDiscovered:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) that were newly discovered by SailPoint CIEM.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the discovered cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  scopesEnabled:
+    type: boolean
+    description: Whether the newly discovered scopes have been automatically enabled for monitoring by SailPoint CIEM.
+    example: true
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) that the scopes were detected on.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the new scope(s) were detected by SailPoint CIEM.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes discovered in this event.
+    example: 3
+  truncated:
+    type: boolean
+    description: Whether the `scopesDiscovered` list was truncated because the total number of discovered scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/v2025/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
+++ b/static/api-specs/idn/v2025/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
@@ -1,0 +1,59 @@
+title: CIEM Scope Selection Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: ScopeSelectionChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the scope selection.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the scope selection.
+    example: 2c7180a46faadee4016fb4e018c20648
+  scopesModified:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) whose selection was changed for this CIEM source.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose scope selection was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the scope selection was changed.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes modified in this event.
+    example: 2
+  truncated:
+    type: boolean
+    description: Whether the `scopesModified` list was truncated because the total number of modified scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/v2025/webhooks/ciem-auto-include-scope-setting-changed.yaml
+++ b/static/api-specs/idn/v2025/webhooks/ciem-auto-include-scope-setting-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM auto-include scope setting changed
+  operationId: ciemAutoIncludeScopeSettingChangedEvent
+  description: >-
+    This event trigger fires when a user disables or enables the Auto-Include Scope functionality for a source. When auto-include scope is disabled, SailPoint CIEM will not check for newly added AWS accounts, Azure subscriptions, or GCP projects.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Auto-Include Scope Setting Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-auto-include-scope-setting-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml'

--- a/static/api-specs/idn/v2025/webhooks/ciem-new-scope-detected.yaml
+++ b/static/api-specs/idn/v2025/webhooks/ciem-new-scope-detected.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM new scope detected
+  operationId: ciemNewScopeDetectedEvent
+  description: >-
+    This event trigger fires when SailPoint CIEM detects a new AWS account, Azure subscription, or GCP project for a source.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM New Scope Detected](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-new-scope-detected).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemNewScopeDetected.yaml'

--- a/static/api-specs/idn/v2025/webhooks/ciem-scope-selection-changed.yaml
+++ b/static/api-specs/idn/v2025/webhooks/ciem-scope-selection-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM scope selection changed
+  operationId: ciemScopeSelectionChangedEvent
+  description: >-
+    This event trigger fires when a user changes the scope selection for a source. If a cloud scope is deselected, SailPoint CIEM will no longer check for changes to that specific AWS account, Azure subscription, or GCP project.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Scope Selection Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-scope-selection-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemScopeSelectionChanged.yaml'

--- a/static/api-specs/idn/v2026/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
+++ b/static/api-specs/idn/v2026/schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml
@@ -1,0 +1,32 @@
+title: CIEM Auto-Include Scope Setting Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: AutoIncludeScopeSettingChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the Auto-Include Scope setting.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the Auto-Include Scope setting.
+    example: 2c7180a46faadee4016fb4e018c20648
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose Auto-Include Scope setting was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the Auto-Include Scope setting was changed.
+    example: "2024-03-29T22:01:50.474Z"

--- a/static/api-specs/idn/v2026/schemas/trigger/example-input/CiemNewScopeDetected.yaml
+++ b/static/api-specs/idn/v2026/schemas/trigger/example-input/CiemNewScopeDetected.yaml
@@ -1,0 +1,59 @@
+title: CIEM New Scope Detected
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: NewScopeDetected
+  org:
+    type: string
+    description: The ISC tenant (org) where the event occurred.
+    example: acme-sb
+  scopesDiscovered:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) that were newly discovered by SailPoint CIEM.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the discovered cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  scopesEnabled:
+    type: boolean
+    description: Whether the newly discovered scopes have been automatically enabled for monitoring by SailPoint CIEM.
+    example: true
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) that the scopes were detected on.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the new scope(s) were detected by SailPoint CIEM.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes discovered in this event.
+    example: 3
+  truncated:
+    type: boolean
+    description: Whether the `scopesDiscovered` list was truncated because the total number of discovered scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/v2026/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
+++ b/static/api-specs/idn/v2026/schemas/trigger/example-input/CiemScopeSelectionChanged.yaml
@@ -1,0 +1,59 @@
+title: CIEM Scope Selection Changed
+type: object
+additionalProperties: true
+properties:
+  event:
+    type: string
+    description: The name of the CIEM event that was emitted.
+    example: ScopeSelectionChanged
+  identityDisplayName:
+    type: string
+    description: The display name of the identity who changed the scope selection.
+    example: William Wilson
+  identityId:
+    type: string
+    description: The ID of the identity who changed the scope selection.
+    example: 2c7180a46faadee4016fb4e018c20648
+  scopesModified:
+    type: array
+    description: The cloud scopes (AWS accounts, Azure subscriptions, or GCP projects) whose selection was changed for this CIEM source.
+    items:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+        - nativeId
+      properties:
+        name:
+          type: string
+          description: The human friendly name of the cloud scope.
+          example: aws-prod-payments
+        nativeId:
+          type: string
+          description: The cloud-native identifier of the scope (AWS account ID, Azure subscription ID, or GCP project ID).
+          example: "123456789012"
+  sourceIscId:
+    type: string
+    description: The unique ID of the source in Identity Security Cloud (ISC) whose scope selection was changed.
+    example: 2c9180866166b5b0016167c32ef31a66
+  sourceName:
+    type: string
+    description: The human friendly name of the source.
+    example: AWS Production
+  sourceNativeId:
+    type: string
+    description: The cloud-native identifier of the source (for example, the AWS organization ID or Azure tenant ID).
+    example: o-abcd1234ef
+  timestamp:
+    type: string
+    description: The date and time the scope selection was changed.
+    example: "2024-03-29T22:01:50.474Z"
+  total:
+    type: integer
+    minimum: 1
+    description: The total number of scopes modified in this event.
+    example: 2
+  truncated:
+    type: boolean
+    description: Whether the `scopesModified` list was truncated because the total number of modified scopes exceeded the payload limit.
+    example: false

--- a/static/api-specs/idn/v2026/webhooks/ciem-auto-include-scope-setting-changed.yaml
+++ b/static/api-specs/idn/v2026/webhooks/ciem-auto-include-scope-setting-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM auto-include scope setting changed
+  operationId: ciemAutoIncludeScopeSettingChangedEvent
+  description: >-
+    This event trigger fires when a user disables or enables the Auto-Include Scope functionality for a source. When auto-include scope is disabled, SailPoint CIEM will not check for newly added AWS accounts, Azure subscriptions, or GCP projects.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Auto-Include Scope Setting Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-auto-include-scope-setting-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemAutoIncludeScopeSettingChanged.yaml'

--- a/static/api-specs/idn/v2026/webhooks/ciem-new-scope-detected.yaml
+++ b/static/api-specs/idn/v2026/webhooks/ciem-new-scope-detected.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM new scope detected
+  operationId: ciemNewScopeDetectedEvent
+  description: >-
+    This event trigger fires when SailPoint CIEM detects a new AWS account, Azure subscription, or GCP project for a source.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM New Scope Detected](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-new-scope-detected).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemNewScopeDetected.yaml'

--- a/static/api-specs/idn/v2026/webhooks/ciem-scope-selection-changed.yaml
+++ b/static/api-specs/idn/v2026/webhooks/ciem-scope-selection-changed.yaml
@@ -1,0 +1,19 @@
+post:
+  summary: CIEM scope selection changed
+  operationId: ciemScopeSelectionChangedEvent
+  description: >-
+    This event trigger fires when a user changes the scope selection for a source. If a cloud scope is deselected, SailPoint CIEM will no longer check for changes to that specific AWS account, Azure subscription, or GCP project.
+
+    This is a `FIRE_AND_FORGET` event trigger.
+    You can have a maximum of 50 subscriptions for this trigger.
+    For more information about this event trigger, refer to [CIEM Scope Selection Changed](https://developer.sailpoint.com/docs/extensibility/event-triggers/triggers/ciem-scope-selection-changed).
+  tags:
+    - Triggers
+  security:
+    - userAuth: [sp:trigger-service-subscriptions:manage]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/trigger/example-input/CiemScopeSelectionChanged.yaml'


### PR DESCRIPTION
- Created documentation for three new event triggers:
  1. CIEM Auto-Include Scope Setting Changed
  2. CIEM New Scope Detected
  3. CIEM Scope Selection Changed

Each document includes event context, example input, and additional information regarding trigger types.