### PR TITLE
docs(role/dimension criteria): fix 'children or OR nodes' -> 'children of OR nodes'

### DIFF
--- a/docs/tools/sdk/go/Reference/Beta/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/Beta/Models/RoleCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/Beta/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/Beta/Models/RoleCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2024/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V2024/Models/DimensionCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableDimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2024/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V2024/Models/DimensionCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableDimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2024/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V2024/Models/RoleCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2024/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V2024/Models/RoleCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2025/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V2025/Models/DimensionCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableDimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2025/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V2025/Models/DimensionCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableDimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2025/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V2025/Models/RoleCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2025/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V2025/Models/RoleCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2026/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V2026/Models/DimensionCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableDimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2026/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V2026/Models/DimensionCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableDimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2026/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V2026/Models/RoleCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V2026/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V2026/Models/RoleCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V3/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/go/Reference/V3/Models/RoleCriteriaLevel1.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/go/Reference/V3/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/go/Reference/V3/Models/RoleCriteriaLevel2.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **Operation** | Pointer to [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | Pointer to [**NullableRoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | Pointer to **NullableString** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | Pointer to [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Methods
 

--- a/docs/tools/sdk/powershell/Reference/Beta/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/powershell/Reference/Beta/Models/RoleCriteriaLevel1.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/Beta/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/powershell/Reference/Beta/Models/RoleCriteriaLevel2.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2024/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/powershell/Reference/V2024/Models/DimensionCriteriaLevel1.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2024/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/powershell/Reference/V2024/Models/DimensionCriteriaLevel2.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2024/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/powershell/Reference/V2024/Models/RoleCriteriaLevel1.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2024/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/powershell/Reference/V2024/Models/RoleCriteriaLevel2.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2025/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/powershell/Reference/V2025/Models/DimensionCriteriaLevel1.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2025/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/powershell/Reference/V2025/Models/DimensionCriteriaLevel2.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **Key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2025/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/powershell/Reference/V2025/Models/RoleCriteriaLevel1.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V2025/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/powershell/Reference/V2025/Models/RoleCriteriaLevel2.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V3/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/powershell/Reference/V3/Models/RoleCriteriaLevel1.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/powershell/Reference/V3/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/powershell/Reference/V3/Models/RoleCriteriaLevel2.md
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 **Operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **Key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **StringValue** | **String** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**Children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 
 ## Examples
 

--- a/docs/tools/sdk/python/Reference/Beta/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/python/Reference/Beta/Models/RoleCriteriaLevel1.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/Beta/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/python/Reference/Beta/Models/RoleCriteriaLevel2.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2024/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/python/Reference/V2024/Models/DimensionCriteriaLevel1.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2024/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/python/Reference/V2024/Models/DimensionCriteriaLevel2.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2024/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/python/Reference/V2024/Models/RoleCriteriaLevel1.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2024/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/python/Reference/V2024/Models/RoleCriteriaLevel2.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2025/Models/DimensionCriteriaLevel1.md
+++ b/docs/tools/sdk/python/Reference/V2025/Models/DimensionCriteriaLevel1.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is  EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]DimensionCriteriaLevel2**](dimension-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2025/Models/DimensionCriteriaLevel2.md
+++ b/docs/tools/sdk/python/Reference/V2025/Models/DimensionCriteriaLevel2.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**DimensionCriteriaOperation**](dimension-criteria-operation) |  | [optional] 
 **key** | [**DimensionCriteriaKey**](dimension-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]DimensionCriteriaLevel3**](dimension-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2025/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/python/Reference/V2025/Models/RoleCriteriaLevel1.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V2025/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/python/Reference/V2025/Models/RoleCriteriaLevel2.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V3/Models/RoleCriteriaLevel1.md
+++ b/docs/tools/sdk/python/Reference/V3/Models/RoleCriteriaLevel1.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel2**](role-criteria-level2) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/docs/tools/sdk/python/Reference/V3/Models/RoleCriteriaLevel2.md
+++ b/docs/tools/sdk/python/Reference/V3/Models/RoleCriteriaLevel2.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **operation** | [**RoleCriteriaOperation**](role-criteria-operation) |  | [optional] 
 **key** | [**RoleCriteriaKey**](role-criteria-key) |  | [optional] 
 **string_value** | **str** | String value to test the Identity attribute, Account attribute, or Entitlement specified in the key w/r/t the specified operation. If this criteria is a leaf node, that is, if the operation is one of EQUALS, NOT_EQUALS, CONTAINS, STARTS_WITH, or ENDS_WITH, this field is required. Otherwise, specifying it is an error. | [optional] 
-**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children or OR nodes and vice-versa. | [optional] 
+**children** | [**[]RoleCriteriaLevel3**](role-criteria-level3) | Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be children of OR nodes and vice-versa. | [optional] 
 }
 
 ## Example

--- a/static/api-specs/idn/v2024/schemas/access/DimensionCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v2024/schemas/access/DimensionCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2024/schemas/access/DimensionCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v2024/schemas/access/DimensionCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2024/schemas/access/RoleCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v2024/schemas/access/RoleCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2024/schemas/access/RoleCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v2024/schemas/access/RoleCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2025/schemas/access/DimensionCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v2025/schemas/access/DimensionCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2025/schemas/access/DimensionCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v2025/schemas/access/DimensionCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2025/schemas/access/RoleCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v2025/schemas/access/RoleCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2025/schemas/access/RoleCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v2025/schemas/access/RoleCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2026/schemas/access/DimensionCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v2026/schemas/access/DimensionCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2026/schemas/access/DimensionCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v2026/schemas/access/DimensionCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2026/schemas/access/RoleCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v2026/schemas/access/RoleCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v2026/schemas/access/RoleCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v2026/schemas/access/RoleCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v3/schemas/access/DimensionCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v3/schemas/access/DimensionCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v3/schemas/access/DimensionCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v3/schemas/access/DimensionCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v3/schemas/access/RoleCriteriaLevel1.yaml
+++ b/static/api-specs/idn/v3/schemas/access/RoleCriteriaLevel1.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             

--- a/static/api-specs/idn/v3/schemas/access/RoleCriteriaLevel2.yaml
+++ b/static/api-specs/idn/v3/schemas/access/RoleCriteriaLevel2.yaml
@@ -23,5 +23,5 @@ properties:
         description: >-
             Array of child criteria. Required if the operation is AND or OR, otherwise it must be left null. A maximum
             of three levels of criteria are supported, including leaf nodes. Additionally, AND nodes can only be
-            children or OR nodes and vice-versa.
+            children of OR nodes and vice-versa.
             


### PR DESCRIPTION
## Summary

The \`children\` field description for \`RoleCriteriaLevel1\`, \`RoleCriteriaLevel2\`, \`DimensionCriteriaLevel1\`, and \`DimensionCriteriaLevel2\` reads:

> Additionally, AND nodes can only be children *or* OR nodes and vice-versa.

That doesn't parse — the rule being documented is that AND nodes can only appear as **children of** OR nodes (and vice versa). Fixing \`or\` -> \`of\` everywhere it appears.

Scope — the same description string was duplicated across every API version and every generated SDK surface, so the fix touches 56 files:

- OpenAPI specs: \`static/api-specs/idn/{v3,v2024,v2025,v2026}/schemas/access/{Role,Dimension}CriteriaLevel{1,2}.yaml\`
- Generated SDK reference docs: \`docs/tools/sdk/{go,python,powershell}/Reference/{Beta,V3,V2024,V2025,V2026}/Models/{Role,Dimension}CriteriaLevel{1,2}.md\`

Each file changes a single line / description.

Closes #1039

## Testing

Documentation-only change. Verified every \`children or OR nodes\` occurrence was replaced and no other wording changed.