### PR TITLE
Fix checkout behavior for forked pull requests

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.3

--- a/.github/workflows/slinky.yml
+++ b/.github/workflows/slinky.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
           
       - name: Run Slinky
         uses: sailpoint-oss/slinky@v1


### PR DESCRIPTION
Fixes #1098
This removes the explicit github.head_ref checkout override so forked pull requests use the default checkout behavior instead of trying to fetch the contributor branch from the upstream repository.
