### PR TITLE
Add Community policies section (Community CoC, Event CoC, overview)

### DIFF
--- a/docs/ai-policy.md
+++ b/docs/ai-policy.md
@@ -5,7 +5,6 @@ description: Guidelines for the responsible use of AI tools in the SailPoint Dev
 slug: /ai-policy
 displayed_sidebar: communityPoliciesSidebar
 hide_table_of_contents: false
-unlisted: true
 custom_edit_url: null
 toc_min_heading_level: 2
 toc_max_heading_level: 2

--- a/docs/ai-policy.md
+++ b/docs/ai-policy.md
@@ -9,15 +9,21 @@ unlisted: true
 custom_edit_url: null
 toc_min_heading_level: 2
 toc_max_heading_level: 2
+last_update:
+  date: 2026-06-18
 ---
+
+<div class="community-policy-page" hidden aria-hidden="true"></div>
 
 ## Purpose
 
-The SailPoint Community welcomes the responsible use of AI tools as part of the learning and problem-solving process. This policy establishes clear guidelines to ensure AI-generated content maintains the quality, accuracy, and educational value our community is known for.
+The SailPoint Developer Community welcomes the responsible use of AI tools as part of the learning and problem-solving process. This policy establishes clear guidelines to ensure AI-generated content maintains the quality, accuracy, and educational value our community is known for.
+
+By participating in the Developer Community, you agree to uphold the standards outlined in this Policy. This Policy is in addition to our [Community Program Terms](https://community.sailpoint.com/t5/Community-Rules/SailPoint-Community-Program-Terms/ta-p/142952) and will be updated from time to time. Additional policies and rules around AI use may apply, as set forth by your organization, please reach out to your organization admin if there are any questions. For SailPoint employees, please consult all relevant AI policies and guidelines.
 
 ## Scope
 
-This policy applies to all members of the SailPoint Community, including:
+This policy applies to all members of the SailPoint Developer Community, including:
 
 - Community members
 - Ambassadors and Expert Ambassadors
@@ -53,23 +59,21 @@ Include a disclosure statement such as:
 
 - "This response was generated with assistance from [AI tool name] and validated against SailPoint documentation."
 - "AI-assisted response - verified against my personal experience with ISC."
-- "Generated using [tool] and tested in my sandbox environment."
+- "Generated using [AI tool name] and tested in my sandbox environment."
 
 Place the disclosure at the beginning or end of your post in a clear, visible manner.
 
 **Do not:**
 
 - Post AI-generated content without disclosure
-- Use vague attributions like "found this online" when it's AI-generated
+- Use vague attributions like "found this online" when it's AI-generated content
 - Hide AI usage after being questioned
 
 ### 2. Validation Requirement
 
 **You must validate AI-generated information before posting.**
 
-Every AI-assisted contribution must be verified and tested:
-
-Verify against at least one of the following:
+Every AI-assisted contribution must be verified and tested by a human. Verify against at least one of the following:
 
 - Official SailPoint documentation
 - Your personal testing in a sandbox/demo environment
@@ -79,14 +83,14 @@ Verify against at least one of the following:
 
 Test before providing code solutions:
 
-- Run the code in your environment
+- Run the code in your test environment
 - Verify it produces expected results
 - Note any limitations or environment-specific requirements
 
 **Do not:**
 
 - Copy-paste AI responses without verification
-- Share untested code or configurations
+- Share untested or unvalidated code or configurations
 - Assume AI information is accurate without checking
 
 ### 3. Value-Add Requirement
@@ -159,7 +163,7 @@ When AI provides information, you must:
 
 - Using AI to generate malicious code
 - Creating deceptive or misleading security advice
-- Generating content that violates our Code of Conduct
+- Generating content that violates our [Code of Conduct](/docs/community-code-of-conduct)
 
 ---
 
@@ -170,7 +174,7 @@ When AI provides information, you must:
 **Example 1: Code Solution with Context**
 
 ```text
-*AI-assisted response - validated in my ISC sandbox*
+AI-assisted response - validated in my ISC sandbox
 
 Based on the requirement to transform account data, here's an approach
 using a transform. I used AI to help structure the JSON, then tested
@@ -235,13 +239,13 @@ all generic, just to accumulate points]
    - Provide context about your use case
 
 2. **Request sources**
-   - Ask AI to cite documentation
+   - Ask AI to cite documentation and list all sources used in its deliberation
    - Verify any URLs or references provided
-   - Cross-check against official SailPoint docs
+   - Cross-check against official SailPoint documentation
 
 3. **Iterate and refine**
    - Start with AI output as a draft
-   - Add your expertise and testing results
+   - Add your expertise and testing results to validate the output
    - Customize to the specific question
 
 4. **Check for hallucinations**
@@ -255,7 +259,7 @@ all generic, just to accumulate points]
 
 ### Progressive Enforcement Approach
 
-We believe in education first, but repeat violations will result in escalating consequences.
+We believe in education first, but repeat violations will result in escalating consequences. As a reminder, under our [Community Program Terms](https://community.sailpoint.com/t5/Community-Rules/SailPoint-Community-Program-Terms/ta-p/142952), we reserve the right to terminate or suspend your rights to use the Community Program for any reason.
 
 **First Violation - Reminder**
 
@@ -273,7 +277,7 @@ We believe in education first, but repeat violations will result in escalating c
 
 - Permanent posting ban
 - Account converted to read-only
-- Removal from Ambassador program if applicable
+- Removal from Ambassador Program if applicable
 
 ### Aggravating Factors
 
@@ -287,21 +291,9 @@ Certain behaviors will result in immediate escalation:
 
 If you believe enforcement action was taken in error:
 
-1. Send an email to [compass-help@sailpoint.com](mailto:compass-help@sailpoint.com) within 14 days
+1. Send an email to [compass-help@sailpoint.com](mailto:compass-help@sailpoint.com) within 14 days from enforcement action
 2. Provide evidence of your case
-3. Appeals reviewed within 5 business days
+3. Appeals reviewed within 14 business days, all decisions are made in our sole discretion
 4. Decision is final after appeal review
 
----
-
-## Questions & Updates
-
-**Questions about this policy:**
-
-- General questions: Post in the [Community Feedback category](https://developer.sailpoint.com/discuss/c/community-feedback/8)
-
-**Policy updates:** This policy will be reviewed annually and updated as needed.
-
----
-
-Thank you for helping maintain the quality and integrity of the SailPoint Community!
+Thank you for helping maintain the quality and integrity of the SailPoint Developer Community.

--- a/docs/ai-policy.md
+++ b/docs/ai-policy.md
@@ -2,14 +2,14 @@
 id: ai-policy
 title: AI Usage Policy
 description: Guidelines for the responsible use of AI tools in the SailPoint Developer Community.
-slug: ai-policy
+slug: /ai-policy
+displayed_sidebar: communityPoliciesSidebar
+hide_table_of_contents: false
 unlisted: true
 custom_edit_url: null
 toc_min_heading_level: 2
 toc_max_heading_level: 2
 ---
-
-<div id="ai-policy-page" class="ai-policy-page-marker" hidden aria-hidden="true"></div>
 
 ## Purpose
 

--- a/docs/ambassador-agreement.md
+++ b/docs/ambassador-agreement.md
@@ -1,0 +1,138 @@
+---
+id: ambassador-agreement
+title: Ambassador Program Agreement
+description: The legal agreement governing participation in the SailPoint Ambassador Program.
+slug: /ambassador-agreement
+displayed_sidebar: communityPoliciesSidebar
+unlisted: true
+custom_edit_url: null
+hide_table_of_contents: true
+last_update:
+  date: 2026-06-17
+---
+
+<div class="community-policy-page" hidden aria-hidden="true"></div>
+
+*Last Updated June 17, 2026*
+
+This Ambassador Program Agreement (the "Agreement") is a legal contract between the individual who accepts these terms ("Ambassador," "you" and "your") and SailPoint Technologies, Inc. (together with its affiliates, "SailPoint," "we" or "our"). Your participation in the Ambassador Program (the "Program") is subject to the terms of this Agreement. By clicking on the "I accept" button, or by participating in the Program, you agree to be bound by this Agreement. Please carefully read this Agreement. If you do not agree to the terms of this Agreement, do not click "I accept" or participate in the Program.
+
+---
+
+## 1. Program basics
+
+The Program is designed to give you the opportunity to participate in our developer community and deepen your familiarity with SailPoint's identity security products and services ("SailPoint Services"). To participate in the Program, you must be at least the age of majority in the country you live in (usually 18 years), and by entering into this Agreement you certify to SailPoint that you are at least the age of majority where you live. Because we may share confidential information about SailPoint's product features and plans with Program members, we do not permit employees of our competitors to participate in the Program. You hereby certify that you are either an employee or authorized representative of a current or prospective customer or partner of SailPoint. If you use any SailPoint community, support and engagement tools, such as the SailPoint Developer Community, Compass website; support portal; Identity University; Ideas portal, or any other SailPoint portal, product or tool that links to or incorporates additional terms, you agree to comply with all applicable terms for such tools. If there is a conflict between this Agreement and the terms in the prior sentence, the terms of this Agreement shall control with respect to all matters related to your participation in the Program.
+
+---
+
+## 2. Program details and benefits
+
+Program members may receive certain benefits from SailPoint that are available only to Program members and not generally to other SailPoint customers and users ("SailPoint Customers"). Additional details relating to the Program such as benefits and membership requirements (including but not limited to the calculation and retention of membership points) can be located at the Developer Community website, available at [developer.sailpoint.com/ambassadors](https://developer.sailpoint.com/ambassadors/) ("Program Guide"), hereby incorporated by reference as part of the Agreement. In accordance with the Program Guide, your Program benefits and perks may vary depending on which Program membership tier you qualify for.
+
+---
+
+## 3. Program changes
+
+You acknowledge that SailPoint may modify the Program or Agreement terms (including the Program Guide) from time to time. In doing so, SailPoint may provide advance notice of any updates and/or general communications with you about the Program via its regular communication channels with Program members, including to email addresses you have provided to SailPoint in connection with the Program; we will endeavor to provide at least fourteen (14) day's notice of any material changes or modifications related to the Program membership benefits, including calculation of Program points. By continuing to participate in the Program, you agree that you accept all of our modifications to this Agreement; in the case of changes or modifications to Program membership benefits, your continued participation after the fourteen (14) days' notice period constitutes acceptance of such changes. If you do not agree to changes to the Agreement terms (including the Program Guide), you must stop participating in the Program immediately.
+
+---
+
+## 4. SailPoint materials
+
+As part of the Program, SailPoint may make available to you promotional materials, training documentation, Test Materials (defined below) and other materials related to the SailPoint Service (collectively and individually, the "SailPoint Materials"). Subject to your compliance with the Agreement terms, SailPoint grants you, during the term of this Agreement, a personal, limited, revocable, non-exclusive, non-transferable right to use the SailPoint Materials worldwide, for the sole and exclusive purpose of your personal enjoyment and participation in the Program. Please note that any violation or breach of this Section 4 may result in your prompt removal from the Program.
+
+### 4.1 Test materials
+
+As set forth in the Program Guide, SailPoint may make available to you a preproduction or sandbox instance of the SailPoint Service(s) ("Test Materials"). Subject to your compliance with the Agreement terms, and for the period you remain eligible to receive access under the Program Guide, SailPoint grants you a personal, limited, revocable, non-exclusive, non-transferrable, non-sublicensable right to access and use the Test Materials on a non-production basis, solely for internally evaluating and testing the SailPoint Service(s), in accordance with any applicable documentation provided by SailPoint (if any). To receive and use Test Materials, the email registered with your Developer Community account must be under an existing or prospective SailPoint customer or partner email domain; access to Test Materials through personal email or non-customer or partner emails will be denied. To update your Developer Community account email, request an email address change at [login-help@sailpoint.com](mailto:login-help@sailpoint.com). You represent and warrant that you shall not grant administrative rights or log-in credentials to the Test Materials to any person other than yourself, and you will maintain strong passwords to all accounts. You shall be solely responsible for all activities conducted through your account and maintain security and confidentiality of your account. You shall notify SailPoint promptly of any such unauthorized access or use. SailPoint does not provide support, warranties, service level commitments, or indemnification for the Test Materials. You are solely responsible for maintaining a back-up of any data that you submit to the Test Materials. Access to the Test Materials may be terminated or suspended at any time in SailPoint's discretion, including after extended periods of non-use, and any data provided through such Test Materials prior to such termination or suspension may not be capable of being transferred or retained by SailPoint for use or access by you.
+
+### 4.2 Test materials use restrictions
+
+You shall not, and shall not permit others to:
+
+a. Access the Test Materials or any applicable documentation, or SailPoint's confidential information to develop a product or service in competition with SailPoint's products or services;
+
+b. Rent, sublicense, resell, assign, distribute, time share or otherwise commercially exploit the Test Materials;
+
+c. Store in the Test Materials any production or confidential information, personal or sensitive data, key material or certificates of any kind;
+
+d. Use the Test Materials to (or submit, upload or store in the Test Materials any content or data that) violate any applicable laws, any third-party intellectual property rights, or an individual's right of privacy or publicity;
+
+e. Use the Test Materials to create, use, send, store, or run viruses, bots, worms, or similar harmful material;
+
+f. Overload the capacity of the Test Materials or the system or network for such Test Materials or cause significant slowdown or burden to the same. Prohibited activities include but are not limited to load testing, stress testing, large source aggregations or bulk API operations;
+
+g. Allow administrative accounts or other account credentials to be shared or used by more than one individual, or by any individual other than yourself;
+
+h. Reverse engineer, copy, modify, adapt, or hack the Test Materials; or
+
+i. Perform penetration testing or other benchmarking on the Test Materials.
+
+---
+
+## 5. SailPoint trademark and brand guidelines
+
+As a condition of your participation in the Program, you agree to comply with the requirements set forth at [SailPoint Brand Center](https://brand.sailpoint.com/844e6c661/p/9864fd-sailpoint-brand-center), as updated from time to time by SailPoint, whenever you use the SailPoint name, logos, artwork, or other brand features ("SailPoint Brand Assets"). If you are eligible to use any Program-specific logos or marks in accordance with the eligibility standards specified by SailPoint (such as when using the contents in your custom social share package), you are permitted to use such logos or marks only in accordance with the terms of this Agreement and the SailPoint Brand Center requirements. Failure to comply with the terms of this Section may result in immediate suspension or termination of your participation in the Program. Notwithstanding anything else, you shall not use the "SailPoint" name, any variation or similar name thereof in your username or display name on any SailPoint Developer Community platform.
+
+---
+
+## 6. Confidential information
+
+All information provided to you by SailPoint that is not generally known or available to the public, that concerns SailPoint's business, technology, pricing, employees, customers, prospective customers, or financial affairs, including, without limitation, product roadmap information, other confidential plans for the SailPoint Service, and information which is identified by SailPoint as confidential or which a reasonable person would deem to be confidential under the circumstances (collectively, "Confidential Information") is and shall be SailPoint's exclusive property. You shall protect the Confidential Information from disclosure and you shall not disclose any Confidential Information to any person or entity without prior written approval by an officer of SailPoint, either during or after the term of this Agreement. Except with SailPoint's express prior written consent, or as required by law, you shall not use any Confidential Information except for the purpose of participating in the Program. You must cease using, return to SailPoint, and destroy all copies and extracts of all Confidential Information (including electronic files), immediately upon receipt of a request by SailPoint, and you must promptly confirm in writing that you have done so. If you become legally compelled to disclose any Confidential Information, you shall, if lawfully permitted to do so, immediately provide SailPoint with written notice and reasonable cooperation so that SailPoint may seek a protective order or other appropriate remedy to protect its interest in the Confidential Information. If you disclose or use (or threaten to disclose or use) any Confidential Information in breach of this Section 6, SailPoint shall have the right, in addition to any other remedies available to it, to seek injunctive relief to enjoin such acts.
+
+**PLEASE READ THE FOLLOWING CAREFULLY:** Without limiting the foregoing: (a) if SailPoint provides you with or you otherwise have access to information about any SailPoint Customer(s), including without limitation any contact information or statistical information about such SailPoint Customer's use of the SailPoint Service, you shall use such information solely to assist such SailPoint Customer to optimize and enhance its use of the SailPoint Service; and (b) if SailPoint provides you with product roadmap information or other plans for the SailPoint Service or any other inventions or trade secrets, you shall use such information solely for your (or, if you are employed by a SailPoint Customer, the SailPoint Customer's) own internal planning purposes and you shall not disclose the information to anyone.
+
+---
+
+## 7. Intellectual property
+
+Except for the limited rights specifically granted to you in this Agreement, SailPoint reserves all right, title and interest, including, without limitation, all intellectual property rights, in and to the SailPoint Service, the SailPoint Materials, and SailPoint Brand Assets. You agree that this Agreement in no way provides any express or implied license to use or otherwise exploit the SailPoint Service, the SailPoint Materials, or the SailPoint Brand Assets, except as specifically set forth herein. Further, all use of the SailPoint Materials and SailPoint Brand Assets, including all goodwill therein, shall inure to the benefit of SailPoint. If you provide any suggestions, enhancement requests, feedback, recommendations or other information relating to any current or future SailPoint products or services or the SailPoint Materials ("Feedback"), you hereby grant SailPoint an irrevocable, perpetual, nonexclusive, worldwide, transferable, sub-licensable, royalty-free, fully paid up right and license to disclose, use and incorporate such Feedback in order to develop, improve, use, create, commercialize, or exploit any SailPoint products or services, without any compensation to you and without any obligation to provide any accounting or other reporting to you.
+
+---
+
+## 8. Compliance; additional restrictions
+
+You agree to comply with all applicable laws and regulations in participating in the Program. You represent and warrant that you shall not: (a) make any inconsistent, false or misleading representations with respect to SailPoint, the SailPoint Service, or the SailPoint Materials; (b) hold yourself out as the agent of SailPoint under this Program, or make any representation, warranty or promise for or on behalf of SailPoint, or otherwise attempt to obligate SailPoint in any manner inconsistent with your other agreement(s) with SailPoint; or (c) engage in any deceptive, misleading, or unethical practices that are or might be detrimental to SailPoint or SailPoint Customers or damage SailPoint's reputation. You acknowledge that you have no authority to execute contracts on SailPoint's behalf, or to sell or resell subscriptions, seats, or upgrades to the SailPoint Service under this Program. SailPoint's obligations to SailPoint Customers are set forth in SailPoint's other agreements between SailPoint and such SailPoint Customers, and to the extent you are an employee of such SailPoint Customer, you are additionally bound to those terms. You are legally responsible for any person acting for you or on your behalf. You shall not, at any time during the term of the Program and thereafter, make statements or representations or otherwise communicate, directly or indirectly, in writing, orally, or otherwise that may disparage SailPoint or its respective officers, directors, employees or advisors.
+
+---
+
+## 9. Your materials
+
+You are not required to maintain a website or other third-party materials to participate in the Program. However, if you elect in your own discretion to maintain a website or other third-party materials (collectively, "Your Materials") in connection with your participation in the Program, you are solely responsible for the development, operation, and maintenance of, and all costs associated with, Your Materials, and for the accuracy, timeliness and appropriateness of all content posted on the same. SailPoint disclaims all liability for these matters. You agree that Your Materials shall not engage in any of the unsuitable activities listed in the Agreement terms and you understand and agree that SailPoint may, in its sole discretion, request that you correct or retract Your Materials, or terminate you from the Program for any violations of the Agreement terms.
+
+---
+
+## 10. Term and termination
+
+This Agreement shall commence on the date you click "I accept," or the date you begin to participate in the Program, whichever is earliest and continue in effect until terminated by either party. Either party may terminate this Agreement at any time. If you choose to do so, please send an email to [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com). Upon termination, all rights and licenses granted to you under the Program and this Agreement shall immediately terminate and you must (a) remove all references to your participation in the Program from any website, publicly available advertising or other media; (b) cease use of, return or destroy all SailPoint Materials in your possession; and (c) otherwise cease from participating in the Program and from making any representation that you are still part of the Program. SailPoint may terminate or suspend your access to all or any part of the Program (or any SailPoint Materials) at any time, upon notice and without liability. For example, SailPoint may revoke your right to use any Program-specific logos or other identifiers you may have been eligible to use (such as "SailPoint Ambassador" badge or icons) at its sole discretion. Notwithstanding any termination or expiration of this Agreement, the terms set forth in Sections 6-15 shall survive and continue in effect.
+
+---
+
+## 11. Non-exclusivity
+
+The rights granted by SailPoint to you in connection with this Agreement are non-exclusive. Except as expressly provided in this Agreement, nothing herein shall limit or otherwise impair either party's freedom to conduct its business. Without limiting the foregoing, you acknowledge and agree that SailPoint may offer products and services that compete with products and services you offer.
+
+---
+
+## 12. Indemnification
+
+You agree to indemnify, defend, and hold SailPoint and its respective officers, directors, employees, members, shareholders, or representatives harmless from and against any claim or demand, including without limitation, reasonable attorneys' fees, made by any third party in connection with or arising out of your participation in the program or your violation of the terms of this Agreement. We reserve the right, at our own expense, to assume the exclusive defense and control of such disputes, and in any event you shall cooperate with SailPoint in asserting any available defenses.
+
+---
+
+## 13. Disclaimer; liability limitation
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM, SAILPOINT MATERIALS AND SAILPOINT BRAND ASSETS ARE PROVIDED "AS IS" WITHOUT WARRANTY, REPRESENTATION, CONDITION, OR GUARANTEE OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES, REPRESENTATIONS, CONDITIONS OR GUARANTEES OF QUALITY, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. YOU ACKNOWLEDGE THAT YOU HAVE NO EXPECTATION AND HAVE NOT RECEIVED ANY ASSURANCE THAT ANY INVESTMENT IN THE PROGRAM SHALL BE RECOVERED OR RECOUPED OR THAT YOU SHALL OBTAIN ANY PROFIT AS A RESULT OF PARTICIPATING IN THE PROGRAM. SAILPOINT SHALL NOT BE LIABLE FOR ANY ACCESS TO, USE OF OR RELIANCE ON THE PROGRAM, THE SAILPOINT MATERIALS OR THE SAILPOINT BRAND ASSETS BY YOU OR ANYONE ELSE, OR FOR ANY TRANSACTIONS, COMMUNICATIONS, INTERACTIONS, DISPUTES OR RELATIONS BETWEEN YOU AND ANY OTHER PERSON OR ORGANIZATION ARISING OUT OF OR RELATED TO SAILPOINT OR THE PROGRAM. YOUR PARTICIPATION IN THE PROGRAM IS AT YOUR OWN RISK.
+
+IN NO EVENT SHALL SAILPOINT OR ITS LICENSORS, VENDORS, OR ANY OF THEIR RESPECTIVE DIRECTORS, OFFICERS, EMPLOYEES, AGENTS, OR OTHER REPRESENTATIVES BE LIABLE TO YOU OR ANY OTHER PERSON OR ENTITY FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES (INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS, LOSS OF DATA, LOSS OF USE, OR COSTS OF OBTAINING SUBSTITUTE GOODS OR SERVICES), ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT OR THE PROGRAM, SAILPOINT MATERIALS AND SAILPOINT BRAND ASSETS, WHETHER OR NOT SAILPOINT HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND WHETHER BASED UPON WARRANTY, CONTRACT, TORT, STRICT LIABILITY, VIOLATION OF STATUTE, OR OTHERWISE. THIS EXCLUSION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW. IN ANY EVENT, SAILPOINT'S AGGREGATE LIABILITY, AND THE AGGREGATE LIABILITY OF OUR LICENSORS AND VENDORS, TO YOU OR ANY THIRD PARTIES ARISING OUT OF OR RELATING TO THIS AGREEMENT IS LIMITED TO $100. THE FOREGOING LIMITATIONS SHALL APPLY EVEN IF A REMEDY FAILS OF ITS ESSENTIAL PURPOSE AND TO THE FULLEST EXTENT PERMITTED BY LAW.
+
+---
+
+## 14. Export compliance
+
+The Program and SailPoint Materials may be subject to export laws and regulations of the United States and other jurisdictions. You represent that you are not named on any U.S. government denied-party list. You shall not permit anyone to access or use any SailPoint Materials in a U.S.-embargoed country or region or in violation of any U.S. export law or regulation.
+
+---
+
+## 15. Miscellaneous
+
+This Agreement (and all terms and conditions incorporated herein) constitutes the entire agreement between you and SailPoint with respect to its subject matter, and supersedes all other proposals, statements and agreements, including any previous agreement relating to the Program. A waiver or consent given by either party on any one occasion shall be effective only in that instance and shall not be construed as a bar or waiver of any right on any other occasion, including any other agreements you have with SailPoint. You agree that, except as otherwise expressly provided in this Agreement, there shall be no third-party beneficiaries to this Agreement. This Agreement and any rights or licenses granted hereunder to you are personal and may not be assigned or delegated by you. This Agreement and any rights or licenses granted hereunder, may be assigned or delegated by SailPoint without restriction. This Agreement may not be modified by an oral statement by a representative of SailPoint. We may deliver notice to you by e-mail, posting a notice on the SailPoint Developer Community website, or any other method we elect and such notice shall be effective on dispatch. Subject to Section 15, the parties agree that exclusive jurisdiction and venue of any action with respect to this Agreement shall be in a state or federal court located in Travis County, Texas, and each of the parties hereby submits to jurisdiction and venue of such courts for the purpose of any such action. If you are located outside the U.S., you acknowledge and agree that this Agreement is only being offered in English, and that if there is any translation of this Agreement, the English version shall govern. Should any provision of this Agreement, or any provision incorporated into this Agreement in the future, be or become invalid or unenforceable, the validity or enforceability of the other provisions of this Agreement shall not be affected thereby. The invalid or unenforceable provision shall be deemed to be substituted by a suitable and equitable provision that, to the extent legal permissible, comes as close as possible to the intent and purpose of the invalid or unenforceable provision. The section titles in this Agreement are for convenience and have no legal or contractual effect.

--- a/docs/community-code-of-conduct.md
+++ b/docs/community-code-of-conduct.md
@@ -1,6 +1,6 @@
 ---
 id: community-code-of-conduct
-title: Community Code of Conduct
+title: Developer Community Code of Conduct
 description: Standards and expectations for all members of the SailPoint Developer Community.
 slug: /community-code-of-conduct
 displayed_sidebar: communityPoliciesSidebar
@@ -16,7 +16,7 @@ toc_max_heading_level: 2
 
 SailPoint is dedicated to providing a welcoming, inclusive, and harassment-free community experience for everyone. We are committed to fostering an environment where questions are met with helpful responses, knowledge is shared openly, diverse perspectives are respected, and technical excellence is celebrated — regardless of age, disability, ethnicity, gender identity, level of experience, nationality, race, religion, or sexual orientation.
 
-By participating, you agree to uphold the standards outlined in this document.
+By participating in the Developer Community, you agree to uphold the standards outlined in this document. These standards are in addition to our [Community Program Terms](https://community.sailpoint.com/t5/Community-Rules/SailPoint-Community-Program-Terms/ta-p/142952) and will be updated from time to time by us.
 
 ## Scope
 
@@ -44,7 +44,7 @@ This Code of Conduct applies to all members of the SailPoint Developer Community
 - Give credit for others' contributions and celebrate community successes
 
 **Diligent**
-- Search before posting — check docs, knowledge base, and existing threads
+- Search before posting: check docs, knowledge base, and existing threads
 - Provide context, version info, and what you've already tried
 - Test solutions before sharing them
 - Follow up when a solution works (or doesn't)
@@ -68,7 +68,7 @@ The following behaviors are prohibited:
 - Malicious code, phishing, or social engineering
 - Content that violates laws or regulations
 - Impersonating others or creating duplicate accounts
-- Using "SailPoint" in your username or display name
+- Using "SailPoint" or any similar variations or spellings thereof in your username or display name
   - This applies to all members, including SailPoint employees
   - Official employees are identified by their SailPoint badge, not their username
 - Using a username or display name that impersonates a SailPoint employee, product, team, or official account
@@ -77,24 +77,25 @@ The following behaviors are prohibited:
 
 ## Posting guidelines
 
-Before posting, search existing discussions and check SailPoint documentation, including the [AI Usage Policy](/docs/ai-policy). When posting:
+Before posting, search existing discussions and check SailPoint documentation, including the [AI Usage Policy](/docs/ai-policy).
 
 **Do:**
 - Write a clear, specific title that describes the actual problem
 - Include product name, version, what you've tried, and relevant error messages
-- Format code using markdown code blocks and remove any sensitive data
+- Format code using markdown code blocks
+- Remove any sensitive data
 - Post in the correct category with helpful tags
 
 **Don't:**
-- Share credentials, API keys, customer data, or PII
-- Post entire customer implementations or NDA-covered configurations
+- Share credentials, API keys, customer data, confidential information, or personally identifiable information
+- Post customer implementations or NDA-covered configurations, materials, or information
 - Request that others do your work for free
 - Post off-topic, political, religious, or inflammatory content
-- Advertise or promote services
+- Advertise or promote services, including your own services
 
 ## Respectful disagreement
 
-Technical discussions often involve differing opinions. Focus on ideas, not people. Explain your reasoning, acknowledge valid points, and be willing to be convinced. Avoid dismissive language ("just Google it"), personal attacks, or continuing to argue after an impasse.
+Technical discussions often involve differing opinions. Focus on ideas, not people. Explain your reasoning, acknowledge valid points, and be willing to be convinced. Avoid dismissive language (for example, "just Google it"), personal attacks, or continuing to argue after an impasse.
 
 ---
 
@@ -102,11 +103,11 @@ Technical discussions often involve differing opinions. Focus on ideas, not peop
 
 ### How to report
 
-To report content that violates this policy, please flag the post, this will notify our community moderators. For private concerns, email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) or message @developer_relations_team on the forum.
+To report content that violates this policy, please flag the post, this will notify our community moderators. For private concerns, use our [incident report form](https://airtable.com/appOsBfB3WsPhsdOn/pago1RFMtxnIsRdnL/form) or message @developer_relations_team on the forum.
 
 Reports are kept confidential. Retaliation against reporters is prohibited. Reporters receive confirmation their report was received.
 
-We believe in education first, but repeat violations will result in escalating consequences.
+We believe in education first, but repeat violations will result in escalating consequences. As a reminder, under our [Community Program Terms](https://community.sailpoint.com/t5/Community-Rules/SailPoint-Community-Program-Terms/ta-p/142952), we reserve the right to terminate or suspend your rights to use the Community Program for any reason.
 
 **1st violation — Reminder**
 - Friendly reminder via private message
@@ -115,7 +116,7 @@ We believe in education first, but repeat violations will result in escalating c
 
 **2nd violation — Warning**
 - Official warning sent
-- Formal acknowledgment of Community Code of Conduct required
+- Formal acknowledgment of Community Code of Conduct required in writing
 
 **3rd violation — Ban**
 - Permanent posting ban
@@ -127,13 +128,13 @@ Some behaviors result in an **immediate permanent ban**, regardless of prior his
 - Harassment, hate speech, or targeted abuse
 - Doxxing or sharing another person's private information
 - Posting malicious code or security exploits
-- Coordinated manipulation, fraud, or sock-puppet accounts
+- Coordinated manipulation, fraud, or sockpuppet accounts
 - Illegal activity
 
 ## Appeals
 
-Any enforcement action of the 2nd violation or above may be appealed within 14 days. Email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) with your perspective and any relevant context. DevRel leadership will review within 5 business days. One appeal per incident, decision is final.
+Any enforcement action of the 2nd violation or above may be appealed within 14 days. Email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) with your perspective and any relevant context. Our Developer Relations leadership will review within 14 days, and all decisions are made in our sole discretion. One appeal per incident, decision is final.
 
 ---
 
-Thank you for being a part of the SailPoint Community.
+Thank you for being a part of the SailPoint Developer Community.

--- a/docs/community-code-of-conduct.md
+++ b/docs/community-code-of-conduct.md
@@ -1,0 +1,139 @@
+---
+id: community-code-of-conduct
+title: Community Code of Conduct
+description: Standards and expectations for all members of the SailPoint Developer Community.
+slug: /community-code-of-conduct
+displayed_sidebar: communityPoliciesSidebar
+unlisted: true
+custom_edit_url: null
+toc_min_heading_level: 2
+toc_max_heading_level: 2
+---
+
+<div class="community-policy-page" hidden aria-hidden="true"></div>
+
+## Our commitment
+
+SailPoint is dedicated to providing a welcoming, inclusive, and harassment-free community experience for everyone. We are committed to fostering an environment where questions are met with helpful responses, knowledge is shared openly, diverse perspectives are respected, and technical excellence is celebrated — regardless of age, disability, ethnicity, gender identity, level of experience, nationality, race, religion, or sexual orientation.
+
+By participating, you agree to uphold the standards outlined in this document.
+
+## Scope
+
+This Code of Conduct applies to all members of the SailPoint Developer Community, including:
+
+- Community members
+- Ambassadors and Expert Ambassadors
+- SailPoint employees
+- Partner representatives
+- Any person posting content in community forums including chat
+
+---
+
+## Expected behavior
+
+**Respectful**
+- Treat everyone with courtesy and professionalism
+- Assume good intent and disagree constructively
+- Use welcoming, inclusive language
+
+**Helpful**
+- Share knowledge generously and guide newcomers patiently
+- Acknowledge when you don't know something
+- Point people to relevant resources
+- Give credit for others' contributions and celebrate community successes
+
+**Diligent**
+- Search before posting — check docs, knowledge base, and existing threads
+- Provide context, version info, and what you've already tried
+- Test solutions before sharing them
+- Follow up when a solution works (or doesn't)
+
+**Professional**
+- Keep discussions on-topic
+- Avoid spam, unsolicited self-promotion, or commercial solicitation
+- Represent yourself and your organization honestly
+
+## Unacceptable behavior
+
+The following behaviors are prohibited:
+
+- Harassment, discrimination, or offensive comments of any kind
+- Sexual attention, personal attacks, or threats
+- Doxxing or publishing private information without consent
+- Spam, flooding, or deliberate derailment of discussions
+- Plagiarism
+- Sharing false, misleading, or unverified technical information
+- Manipulating community systems
+- Malicious code, phishing, or social engineering
+- Content that violates laws or regulations
+- Impersonating others or creating duplicate accounts
+- Using "SailPoint" in your username or display name
+  - This applies to all members, including SailPoint employees
+  - Official employees are identified by their SailPoint badge, not their username
+- Using a username or display name that impersonates a SailPoint employee, product, team, or official account
+
+---
+
+## Posting guidelines
+
+Before posting, search existing discussions and check SailPoint documentation, including the [AI Usage Policy](/docs/ai-policy). When posting:
+
+**Do:**
+- Write a clear, specific title that describes the actual problem
+- Include product name, version, what you've tried, and relevant error messages
+- Format code using markdown code blocks and remove any sensitive data
+- Post in the correct category with helpful tags
+
+**Don't:**
+- Share credentials, API keys, customer data, or PII
+- Post entire customer implementations or NDA-covered configurations
+- Request that others do your work for free
+- Post off-topic, political, religious, or inflammatory content
+- Advertise or promote services
+
+## Respectful disagreement
+
+Technical discussions often involve differing opinions. Focus on ideas, not people. Explain your reasoning, acknowledge valid points, and be willing to be convinced. Avoid dismissive language ("just Google it"), personal attacks, or continuing to argue after an impasse.
+
+---
+
+## Reporting and enforcement
+
+### How to report
+
+To report content that violates this policy, please flag the post, this will notify our community moderators. For private concerns, email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) or message @developer_relations_team on the forum.
+
+Reports are kept confidential. Retaliation against reporters is prohibited. Reporters receive confirmation their report was received.
+
+We believe in education first, but repeat violations will result in escalating consequences.
+
+**1st violation — Reminder**
+- Friendly reminder via private message
+- Post edited or hidden with explanation
+- No formal warning on record
+
+**2nd violation — Warning**
+- Official warning sent
+- Formal acknowledgment of Community Code of Conduct required
+
+**3rd violation — Ban**
+- Permanent posting ban
+- Account converted to read-only
+- Removal from Ambassador program if applicable
+
+Some behaviors result in an **immediate permanent ban**, regardless of prior history:
+
+- Harassment, hate speech, or targeted abuse
+- Doxxing or sharing another person's private information
+- Posting malicious code or security exploits
+- Coordinated manipulation, fraud, or sock-puppet accounts
+- Illegal activity
+
+## Appeals
+
+Any enforcement action of the 2nd violation or above may be appealed within 14 days. Email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) with your perspective and any relevant context. DevRel leadership will review within 5 business days. One appeal per incident, decision is final.
+
+---
+
+Thank you for being a part of the SailPoint Community.

--- a/docs/community-code-of-conduct.md
+++ b/docs/community-code-of-conduct.md
@@ -4,7 +4,6 @@ title: Community Code of Conduct
 description: Standards and expectations for all members of the SailPoint Developer Community.
 slug: /community-code-of-conduct
 displayed_sidebar: communityPoliciesSidebar
-unlisted: true
 custom_edit_url: null
 toc_min_heading_level: 2
 toc_max_heading_level: 2

--- a/docs/community-policies.md
+++ b/docs/community-policies.md
@@ -1,0 +1,20 @@
+---
+id: community-policies
+title: Community policies
+description: The SailPoint Developer Community operates under a set of complementary policy documents designed to maintain quality, foster collaboration, and ensure professional conduct.
+slug: /community-policies
+displayed_sidebar: communityPoliciesSidebar
+unlisted: true
+custom_edit_url: null
+hide_table_of_contents: true
+---
+
+<div class="community-policy-page" hidden aria-hidden="true"></div>
+
+## Overview
+
+The SailPoint Developer Community operates under a set of complementary policy documents designed to maintain quality, foster collaboration, and ensure professional conduct. It is your responsibility as a member of this community to read, understand, and uphold the policies outlined here.
+
+**All community members** must follow the [AI Usage Policy](/docs/ai-policy) and [Community Code of Conduct](/docs/community-code-of-conduct), which establish baseline standards for content quality, respectful behavior, and responsible use of AI tools. The AI Usage Policy specifically requires disclosure, validation, and value-add when using AI assistance, while the Community Code of Conduct outlines expectations for professional interaction, quality posting standards, and consequences for violations. Members participating in SailPoint developer community events, such as Developer Days, livestreams, etc., are expected to follow the [Event Code of Conduct](/docs/event-code-of-conduct).
+
+**Ambassadors** and **Expert Ambassadors** are held to additional standards outlined in the Ambassador Code of Conduct, which supplements both the community-wide policies and the legally binding Ambassador Program Agreement. As community leaders with access to confidential information, early product releases, and enhanced privileges, Ambassadors must exemplify the highest standards of conduct, protect SailPoint's confidential information, follow brand guidelines, and serve as role models for the broader community. These tiered policies work together to create a professional, trustworthy environment where everyone can learn and contribute while ensuring those with elevated status and access uphold correspondingly higher responsibilities.

--- a/docs/community-policies.md
+++ b/docs/community-policies.md
@@ -4,7 +4,6 @@ title: Community policies
 description: The SailPoint Developer Community operates under a set of complementary policy documents designed to maintain quality, foster collaboration, and ensure professional conduct.
 slug: /community-policies
 displayed_sidebar: communityPoliciesSidebar
-unlisted: true
 custom_edit_url: null
 hide_table_of_contents: true
 ---

--- a/docs/event-code-of-conduct.md
+++ b/docs/event-code-of-conduct.md
@@ -4,7 +4,6 @@ title: Event Code of Conduct
 description: Standards and expectations for all participants at SailPoint Developer Community events.
 slug: /event-code-of-conduct
 displayed_sidebar: communityPoliciesSidebar
-unlisted: true
 custom_edit_url: null
 toc_min_heading_level: 2
 toc_max_heading_level: 2

--- a/docs/event-code-of-conduct.md
+++ b/docs/event-code-of-conduct.md
@@ -1,0 +1,99 @@
+---
+id: event-code-of-conduct
+title: Event Code of Conduct
+description: Standards and expectations for all participants at SailPoint Developer Community events.
+slug: /event-code-of-conduct
+displayed_sidebar: communityPoliciesSidebar
+unlisted: true
+custom_edit_url: null
+toc_min_heading_level: 2
+toc_max_heading_level: 2
+---
+
+<div class="community-policy-page" hidden aria-hidden="true"></div>
+
+## Our commitment
+
+SailPoint is committed to providing safe, welcoming, and inclusive events for everyone. This Code of Conduct applies to all participants — attendees, speakers, sponsors, volunteers, and SailPoint staff — across all event spaces, including physical venues, virtual platforms, side events, social gatherings, and online channels used during the event. By participating, you agree to uphold the standards outlined in this document.
+
+---
+
+## Expected behavior
+
+- Be respectful and professional toward all attendees, speakers, sponsors, and staff
+- Use welcoming, inclusive language
+- Engage constructively with content and questions
+- Respect others' time, attention, and personal space
+- Follow instructions from event organizers and moderators
+
+## Unacceptable behavior
+
+- Harassment, intimidation, or discrimination of any kind
+- Offensive, sexist, racist, or otherwise exclusionary comments or jokes
+- Unwelcome physical contact or sexual attention
+- Deliberate interruption of sessions, talks, or networking
+- Photography or recording of attendees without consent
+- Sharing confidential session content without permission
+- Illegal or disruptive behavior
+- Misrepresenting your affiliation or credentials
+
+---
+
+## Virtual event guidelines
+
+For online events, the following additional expectations apply:
+
+- Keep your display name accurate and professional
+- Mute yourself when not speaking
+- Don't share session links, recordings, or materials without explicit permission
+- Chat and reactions should follow the same standards as verbal communication
+- Respect the session format, save questions for designated Q&A time
+- Don't use virtual backgrounds or display images that could be offensive
+
+---
+
+## Reporting an incident
+
+If you experience or witness a Code of Conduct violation during an event, please report it as soon as possible. All reports are taken seriously and handled confidentially.
+
+| Situation | How to report |
+|---|---|
+| During an in-person event | Speak directly with any SailPoint staff member or event organizer |
+| During a virtual event | Message a moderator directly in the event platform, or email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) |
+| After an event | Email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) with details of the incident |
+
+Reporters will not face retaliation. Anonymous reports are accepted for serious concerns.
+
+## Enforcement
+
+We believe in education first, but repeat incidents will result in escalating consequences.
+
+**1st incident — Warning**
+- Private warning from event staff
+- You'll be asked to adjust your behavior to continue participating
+
+**2nd incident — Session removal**
+- Removal from the session or activity
+- Remainder of the event may continue with conditions
+
+**3rd incident — Event removal**
+- Removal from the event
+- May affect eligibility for future SailPoint events
+- Possible community ban
+
+Some behaviors result in **immediate removal from the event**, regardless of prior history:
+
+- Harassment, unwanted physical contact, or threats of any kind
+- Hate speech or discriminatory behavior
+- Sharing or distributing content that violates these standards
+- Illegal activity
+
+---
+
+## Speakers & sponsors
+
+Speakers and sponsors are also subject to this Code of Conduct. Presentations, demos, and sponsored content should not contain material that violates these standards. SailPoint reserves the right to ask speakers or sponsors to modify content that is offensive, exclusionary, or otherwise inappropriate.
+
+---
+
+Thank you for helping make SailPoint events welcoming for everyone.

--- a/docs/event-code-of-conduct.md
+++ b/docs/event-code-of-conduct.md
@@ -1,6 +1,6 @@
 ---
 id: event-code-of-conduct
-title: Event Code of Conduct
+title: Developer Community Event Code of Conduct
 description: Standards and expectations for all participants at SailPoint Developer Community events.
 slug: /event-code-of-conduct
 displayed_sidebar: communityPoliciesSidebar
@@ -8,13 +8,15 @@ unlisted: true
 custom_edit_url: null
 toc_min_heading_level: 2
 toc_max_heading_level: 2
+last_update:
+  date: 2026-06
 ---
 
 <div class="community-policy-page" hidden aria-hidden="true"></div>
 
 ## Our commitment
 
-SailPoint is committed to providing safe, welcoming, and inclusive events for everyone. This Code of Conduct applies to all participants — attendees, speakers, sponsors, volunteers, and SailPoint staff — across all event spaces, including physical venues, virtual platforms, side events, social gatherings, and online channels used during the event. By participating, you agree to uphold the standards outlined in this document.
+SailPoint is committed to providing safe, welcoming, and inclusive events for everyone. This Code of Conduct applies to all participants — attendees, speakers, sponsors, volunteers, and SailPoint staff — across all event spaces, including physical venues, virtual platforms, side events, social gatherings, and online channels used during SailPoint's Developer Community events. By participating, you agree to uphold the standards outlined in this document.
 
 ---
 
@@ -28,12 +30,12 @@ SailPoint is committed to providing safe, welcoming, and inclusive events for ev
 
 ## Unacceptable behavior
 
-- Harassment, intimidation, or discrimination of any kind
+- Harassment, intimidation, or discrimination of any kind, including on the basis of age, disability, ethnicity, gender identity, level of experience, nationality, race, religion, or sexual orientation
 - Offensive, sexist, racist, or otherwise exclusionary comments or jokes
 - Unwelcome physical contact or sexual attention
 - Deliberate interruption of sessions, talks, or networking
-- Photography or recording of attendees without consent
-- Sharing confidential session content without permission
+- Photography or recording of attendees without consent from the participants being photographed or recorded
+- Sharing confidential session content, credentials, API keys, customer data, confidential information, or personally identifiable information
 - Illegal or disruptive behavior
 - Misrepresenting your affiliation or credentials
 
@@ -59,14 +61,14 @@ If you experience or witness a Code of Conduct violation during an event, please
 | Situation | How to report |
 |---|---|
 | During an in-person event | Speak directly with any SailPoint staff member or event organizer |
-| During a virtual event | Message a moderator directly in the event platform, or email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) |
-| After an event | Email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) with details of the incident |
+| During a virtual event | Message a moderator directly in the event platform, or [submit an incident report](https://airtable.com/appOsBfB3WsPhsdOn/pago1RFMtxnIsRdnL/form) |
+| After an event | [Submit an incident report](https://airtable.com/appOsBfB3WsPhsdOn/pago1RFMtxnIsRdnL/form) with details of the incident |
 
-Reporters will not face retaliation. Anonymous reports are accepted for serious concerns.
+Reporters will not face retaliation. Anonymous reports are accepted.
 
 ## Enforcement
 
-We believe in education first, but repeat incidents will result in escalating consequences.
+We believe in education first, but repeat incidents will result in escalating consequences. SailPoint reserves the right, in its sole discretion, to remove any participant from an event or restrict eligibility for future events for any reason.
 
 **1st incident — Warning**
 - Private warning from event staff
@@ -74,14 +76,15 @@ We believe in education first, but repeat incidents will result in escalating co
 
 **2nd incident — Session removal**
 - Removal from the session or activity
-- Remainder of the event may continue with conditions
+- Participation in the remainder of the event may continue with conditions
 
 **3rd incident — Event removal**
 - Removal from the event
 - May affect eligibility for future SailPoint events
 - Possible community ban
+- Removal from the Ambassador Program if applicable
 
-Some behaviors result in **immediate removal from the event**, regardless of prior history:
+Some behaviors result in **immediate removal from the event and may result in a community ban**, regardless of prior history:
 
 - Harassment, unwanted physical contact, or threats of any kind
 - Hate speech or discriminatory behavior
@@ -90,10 +93,20 @@ Some behaviors result in **immediate removal from the event**, regardless of pri
 
 ---
 
-## Speakers & sponsors
+## Appeals
+
+Any enforcement action of the 3rd incident may be appealed within 14 days. Email [developer-relations@sailpoint.com](mailto:developer-relations@sailpoint.com) with your perspective and any relevant context. Developer Relations leadership will review within 14 days, and all decisions are made in SailPoint's sole discretion. One appeal per incident, and the decision is final.
+
+## Speakers and sponsors
 
 Speakers and sponsors are also subject to this Code of Conduct. Presentations, demos, and sponsored content should not contain material that violates these standards. SailPoint reserves the right to ask speakers or sponsors to modify content that is offensive, exclusionary, or otherwise inappropriate.
 
----
+## Related policies
+
+Your participation in SailPoint Developer Community events is also subject to the following terms:
+
+- Compass [Community Program Terms](https://community.sailpoint.com/t5/Community-Rules/SailPoint-Community-Program-Terms/ta-p/142952)
+- [SailPoint Event Privacy Notice](https://www.sailpoint.com/legal/event-privacy-notice/)
+- [SailPoint Privacy Statement](https://www.sailpoint.com/legal/privacy-policy/)
 
 Thank you for helping make SailPoint events welcoming for everyone.

--- a/navbar.ts
+++ b/navbar.ts
@@ -45,10 +45,10 @@ const navbarConfig = {
         position: 'left',
         items: [
           { label: 'Developer forum', to: 'https://developer.sailpoint.com/discuss/' },
-          { label: 'AI Policy', to: '/docs/ai-policy' },
           { label: 'CoLab marketplace', to: '/colab' },
           { label: 'Developer blog', to: '/blog' },
           { label: 'Ambassador program', to: '/ambassadors' },
+          { label: 'Community policies', to: '/docs/community-policies' },
         ],
       },
       {

--- a/sidebars.extensibility.ts
+++ b/sidebars.extensibility.ts
@@ -72,6 +72,19 @@ const sidebars: SidebarsConfig = {
       ],
     },
   ],
+  communityPoliciesSidebar: [
+    {
+      type: 'category',
+      label: 'Community policies',
+      collapsible: false,
+      link: { type: 'doc', id: 'community-policies' },
+      items: [
+        { type: 'doc', id: 'ai-policy', label: 'AI Usage Policy' },
+        { type: 'doc', id: 'community-code-of-conduct', label: 'Community Code of Conduct' },
+        { type: 'doc', id: 'event-code-of-conduct', label: 'Event Code of Conduct' },
+      ],
+    },
+  ],
 };
 
 export default sidebars;

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -471,8 +471,9 @@ const sidebars: SidebarsConfig = {
       link: { type: 'doc', id: 'community-policies' },
       items: [
         { type: 'doc', id: 'ai-policy', label: 'AI Usage Policy' },
-        { type: 'doc', id: 'community-code-of-conduct', label: 'Community Code of Conduct' },
-        { type: 'doc', id: 'event-code-of-conduct', label: 'Event Code of Conduct' },
+        { type: 'doc', id: 'community-code-of-conduct', label: 'Developer Community Code of Conduct' },
+        { type: 'doc', id: 'event-code-of-conduct', label: 'Developer Community Event Code of Conduct' },
+        { type: 'doc', id: 'ambassador-agreement', label: 'Ambassador Program Agreement' },
       ],
     },
   ],

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -462,6 +462,20 @@ const sidebars: SidebarsConfig = {
       items: require('./docs/api/v3/sidebar.ts'),
     },
   ],
+
+  communityPoliciesSidebar: [
+    {
+      type: 'category',
+      label: 'Community policies',
+      collapsible: false,
+      link: { type: 'doc', id: 'community-policies' },
+      items: [
+        { type: 'doc', id: 'ai-policy', label: 'AI Usage Policy' },
+        { type: 'doc', id: 'community-code-of-conduct', label: 'Community Code of Conduct' },
+        { type: 'doc', id: 'event-code-of-conduct', label: 'Event Code of Conduct' },
+      ],
+    },
+  ],
 };
 
 export default sidebars;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -878,6 +878,12 @@ article:has(.ai-policy-page-marker) footer,
 .docItemContainer:has(#ai-policy-page) .theme-last-updated,
 article:has(#ai-policy-page) .theme-last-updated,
 .docItemContainer:has(.ai-policy-page-marker) .theme-last-updated,
-article:has(.ai-policy-page-marker) .theme-last-updated {
+article:has(.ai-policy-page-marker) .theme-last-updated,
+article:has(.community-policy-page) .theme-last-updated,
+article:has(.community-policy-page) footer {
+  display: none !important;
+}
+
+.theme-unlisted-banner {
   display: none !important;
 }


### PR DESCRIPTION
- Community policies overview page at /docs/community-policies
- Community Code of Conduct at /docs/community-code-of-conduct
- Event Code of Conduct at /docs/event-code-of-conduct
- AI Usage Policy updated with community policies sidebar
- Community policies added to navbar under Community dropdown
- Unlisted banner hidden, last-updated footer hidden on policy pages